### PR TITLE
build: compile in ISO C++11 mode

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,8 +1,13 @@
 {
   'variables': {
-    'jstp_base_cflags': ['-Wall', '-Wextra', '-Wno-unused-parameter'],
-    'jstp_debug_cflags': ['-g', '-O0'],
-    'jstp_release_cflags': ['-O3']
+    'jstp_base_ccflags': [
+      '-Wall',
+      '-Wextra',
+      '-Wno-unused-parameter',
+      '-std=c++11'
+    ],
+    'jstp_debug_ccflags': ['-g', '-O0'],
+    'jstp_release_ccflags': ['-O3']
   },
   'targets': [
     {
@@ -16,21 +21,21 @@
       ],
       'configurations': {
         'Debug': {
-          'cflags': ['<@(jstp_debug_cflags)'],
+          'cflags_cc': ['<@(jstp_debug_ccflags)'],
           'xcode_settings': {
-            'OTHER_CFLAGS': ['<@(jstp_debug_cflags)']
+            'OTHER_CPLUSPLUSFLAGS': ['<@(jstp_debug_ccflags)']
           }
         },
         'Release': {
-          'cflags': ['<@(jstp_release_cflags)'],
+          'cflags_cc': ['<@(jstp_release_ccflags)'],
           'xcode_settings': {
-            'OTHER_CFLAGS': ['<@(jstp_release_cflags)']
+            'OTHER_CPLUSPLUSFLAGS': ['<@(jstp_release_ccflags)']
           }
         }
       },
-      'cflags': ['<@(jstp_base_cflags)'],
+      'cflags_cc': ['<@(jstp_base_ccflags)'],
       'xcode_settings': {
-        'OTHER_CFLAGS': ['<@(jstp_base_cflags)']
+        'OTHER_CPLUSPLUSFLAGS': ['<@(jstp_base_ccflags)']
       }
     }
   ]


### PR DESCRIPTION
By default `node-gyp` uses `-std=gnu++0x`. This commit modifies `cflags` to use `-std=c++11`.

@belochub there's a question we need to resolve. For the sake of simplicity I placed `-std=c++11` to `cflags` GYP variable that is applied both to C and C++ sources. Currently it has no side-effects since we have no pure-C sources, and most likely won't have such. Technically it would be more correct to place it into `cflags_cc` and make `cflags_cc` inherit `cflags` explicitly (because strangely `cflags` change their behavior and get ignored in generated C++ flags in `*.target.mk` if there are `cflags_cc` present in `binding.gyp`), but it will result in quite more complex `binding.gyp`.