### PR TITLE
build: improve error handling

### DIFF
--- a/build-native.js
+++ b/build-native.js
@@ -3,9 +3,12 @@
 const fs = require('fs');
 const childProcess = require('child_process');
 
-const nodeGyp = childProcess.spawn('node-gyp', ['rebuild'], { shell: true });
+const EXIT_SUCCESS = 0;
 
+const nodeGyp = childProcess.spawn('node-gyp', ['rebuild'], { shell: true });
 const errorLines = [];
+
+nodeGyp.on('error', showWarning);
 
 nodeGyp.stdout.pipe(process.stdout);
 
@@ -19,9 +22,13 @@ nodeGyp.on('exit', (code) => {
   if (errorLines.length > 0) {
     fs.writeFileSync('builderror.log', errorLines.join('\n'));
   }
-  if (code !== 0) {
-    console.warn('Could not build JSTP native extensions, ' +
-      'JavaScript implementation will be used instead.');
+  if (code !== EXIT_SUCCESS) {
+    showWarning();
   }
   process.exit();
 });
+
+function showWarning() {
+  console.warn('Could not build JSTP native extensions, ' +
+    'JavaScript implementation will be used instead.');
+}


### PR DESCRIPTION
* Handle the situation when a compiler cannot be spawned and `exit` event is not fired.
* Make `0` a named constant.