### PR TITLE
parser: fix possible memory leaks

### DIFF
--- a/src/jsrs_parser.cc
+++ b/src/jsrs_parser.cc
@@ -372,6 +372,7 @@ Local<Value> ParseString(Isolate*    isolate,
   }
 
   if (!is_ended) {
+    delete[] result;
     THROW_EXCEPTION(SyntaxError, "Error while parsing string");
     return String::Empty(isolate);
   }


### PR DESCRIPTION
Fix possible memory leaks in `ParseString` function from `jsrs_parser.cc`.