### PR TITLE
doc: fix mistyped repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Then proceed to the documentation at <https://metarhia.github.io/JSTP/>.
 
 | Implementation | Parser | TCP Client | TCP Server | WebSocket Client | WebSocket Server |
 | --- | :---: | :---: | :---: | :---: | :---: |
-| JavaScript<br>[metarhia/Impress](https://github.com/metarhia/JSTP) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| JavaScript<br>[metarhia/JSTP](https://github.com/metarhia/JSTP) | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Swift<br>[JSTPMobile/iOS](https://github.com/JSTPMobile/iOS) | ✓ | ✓ | ✗ | ✗ | ✗ |
 | Java<br>[JSTPMobile/Java](https://github.com/JSTPMobile/Java) | ✓ | ✓ | ✗ | ✗ | ✗ |
 | Haskell<br>[DzyubSpirit/JSTPHaskell](https://github.com/DzyubSpirit/JSTPHaskell) | ✓ | ✓ | ✓ | ✗ | ✗ |

--- a/doc/index.md
+++ b/doc/index.md
@@ -89,7 +89,7 @@ processing that are based on some simple assumptions:
 
 | Implementation | Parser | TCP Client | TCP Server | WebSocket Client | WebSocket Server |
 | --- | :---: | :---: | :---: | :---: | :---: |
-| JavaScript<br>[metarhia/Impress](https://github.com/metarhia/JSTP) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| JavaScript<br>[metarhia/JSTP](https://github.com/metarhia/JSTP) | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Swift<br>[JSTPMobile/iOS](https://github.com/JSTPMobile/iOS) | ✓ | ✓ | ✗ | ✗ | ✗ |
 | Java<br>[JSTPMobile/Java](https://github.com/JSTPMobile/Java) | ✓ | ✓ | ✗ | ✗ | ✗ |
 | Haskell<br>[DzyubSpirit/JSTPHaskell](https://github.com/DzyubSpirit/JSTPHaskell) | ✓ | ✓ | ✓ | ✗ | ✗ |


### PR DESCRIPTION
Fix incorrect repo name in implementations table that can be found in `README.md` and `doc/index.md`.