### PR TITLE
connection: handle optional callbacks properly

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -36,3 +36,8 @@ common.safeRequire = (moduleName) => {
     return null;
   }
 };
+
+// This function can be used in contexts where a function (e.g., a callback) is
+// required but no actions have to be done.
+//
+common.doNothing = () => {};

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -4,6 +4,7 @@ const events = require('events');
 const timers = require('timers');
 const util = require('util');
 
+const common = require('./common');
 const jsrs = require('./record-serialization');
 const errors = require('./errors');
 const RemoteProxy = require('./remote-proxy');
@@ -73,12 +74,8 @@ Connection.prototype.callMethod = function(
   callback
 ) {
   const packet = this.createPacket('call', interfaceName, methodName, args);
-
-  if (callback) {
-    const packetId = packet.call[0];
-    this._callbacks[packetId] = callback;
-  }
-
+  const packetId = packet.call[0];
+  this._callbacks[packetId] = callback || common.doNothing;
   this._send(packet);
 };
 
@@ -135,19 +132,17 @@ Connection.prototype.notifyStateChange = function(path, verb, value) {
 //
 Connection.prototype.handshake = function(appName, login, password, callback) {
   const packet = this.createPacket('handshake', appName, login, password);
+  const packetId = packet.handshake[0];
 
-  if (callback) {
-    const packetId = packet.handshake[0];
-
-    this._callbacks[packetId] = (error, sessionId) => {
-      if (login && password && !error) {
-        this.username = login;
-      }
-
-      this.sessionId = sessionId;
+  this._callbacks[packetId] = (error, sessionId) => {
+    if (login && password && !error) {
+      this.username = login;
+    }
+    this.sessionId = sessionId;
+    if (callback) {
       callback(error, sessionId);
-    };
-  }
+    }
+  };
 
   this._send(packet);
 };
@@ -182,11 +177,7 @@ Connection.prototype.inspectInterface = function(interfaceName, callback) {
 Connection.prototype.ping = function(callback) {
   const packet = this.createPacket('ping');
   const packetId = packet.ping[0];
-  this._callbacks[packetId] = () => {
-    if (callback) {
-      callback();
-    }
-  };
+  this._callbacks[packetId] = callback || common.doNothing;
   this._send(packet);
 };
 


### PR DESCRIPTION
For some public methods of Connection that perform network actions
callbacks are optional. This commit fixes the behavior of default
actions when a callback function is not passed so that (1) the system
logic is always run and (2) a Connection doesn't complain about
callback packets for unknown source packets.