### PR TITLE
protocol: change the format of handshake packets

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -129,10 +129,22 @@ Handshake packets always have ID equal to `0`. The response contains either
 the key `ok` with a value that is the session identifier or `error` that is
 an array with error code and optional error message.
 
+The action field of handshake requests specifies the authentication strategy.
+There are two supported strategies now:
+
+* `login` — authentication with login and password. The payload is an array of
+  two elements: username and password, both represented as strings.
+* `anonymous` — anonymous session request. The payload is ignored (e.g., `true`
+  or an empty array may be used). For anonymous handshakes the action field can
+  be omitted completely, `anonymous` is implied by default.
+
+More strategies may be added in the future (for example, `session` to reconnect
+to an existing session after connection break due to a network error).
+
 Successful handshake:
 
 ```javascript
-C: {handshake:[0,'example'],marcus:'7b458e1a9dda....67cb7a3e'}
+C: {handshake:[0,'example'],login:['marcus','7b458e1a9dda....67cb7a3e']}
 S: {handshake:[0],ok:'9b71d224bd62...bcdec043'}
 ```
 
@@ -153,7 +165,7 @@ Successful handshake of [Impress](https://github.com/metarhia/Impress) worker
 connecting to a private cloud controller:
 
 ```javascript
-C: {handshake:[0,'impress'],S1N5:'d3ea3d73319b...5c2e5c3a'}
+C: {handshake:[0,'impress'],login:['S1N5','d3ea3d73319b...5c2e5c3a']}
 S: {handshake:[0],ok:'PrivateCloud'}
 ```
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -131,9 +131,11 @@ Connection.prototype.notifyStateChange = function(path, verb, value) {
 //   callback - callback function to invoke after the handshake is completed
 //
 Connection.prototype.handshake = function(appName, login, password, callback) {
-  const packet = this.createPacket('handshake', appName, login, password);
-  const packetId = packet.handshake[0];
+  const packet = login && password ?
+    this.createPacket('handshake', appName, 'login', [login, password]) :
+    this.createPacket('handshake', appName);
 
+  const packetId = packet.handshake[0];
   this._callbacks[packetId] = (error, sessionId) => {
     if (login && password && !error) {
       this.username = login;
@@ -379,26 +381,26 @@ Connection.prototype._processHandshakeRequest = function(packet, keys) {
 
   this.application = application;
 
-  const username = keys[1];
-  const password = packet[username];
+  let authStrategy = keys[1];
+  const credentials = authStrategy && packet[authStrategy];
+  authStrategy = authStrategy || 'anonymous';
 
   this._emitPacketEvent('handshakeRequest', packet, packet.handshake[0], {
     packetType: 'handshake',
     handshakeRequest: true,
-    username,
-    password
+    authStrategy
   });
 
-  const callback = this._onSessionCreated.bind(this, username);
-  this.server.startSession(this, application, username, password, callback);
+  this.server.startSession(this, application, authStrategy, credentials,
+    this._onSessionCreated.bind(this));
 };
 
 // Callback of authentication operation
-//   username - user login, if any
 //   error - error that has occured or null
-//   sessionId - session id or hash
+//   username - user login or null
+//   sessionId - session id
 //
-Connection.prototype._onSessionCreated = function(username, error, sessionId) {
+Connection.prototype._onSessionCreated = function(error, username, sessionId) {
   if (error) {
     this._handshakeError(errors.ERR_AUTH_FAILED);
     return;

--- a/lib/simple-auth.js
+++ b/lib/simple-auth.js
@@ -14,20 +14,23 @@ module.exports = simpleAuth;
 // Start session. Only anonymous handshakes are allowed.
 //   connection - JSTP connection
 //   application - application instance
-//   username - null (required by the auth callback contract)
-//   password - null (required by the auth callback contract)
-//   callback - callback function that has signature (error, sessionId)
+//   strategy - authentication strategy (only 'anonymous' is supported)
+//   credentials - authentication credentials
+//   callback - callback function that has signature
+//              (error, username, sessionId)
 //
-simpleAuth.startSession = (connection, application,
-                           username, password, callback) => {
-  if (username) {
+simpleAuth.startSession = (
+  connection, application,
+  strategy, credentials, callback
+) => {
+  if (strategy !== 'anonymous') {
     return callback(errors.ERR_AUTH_FAILED);
   }
 
   const sessionId = generateUuid4();
   simpleAuth.emit('session', sessionId, connection, application);
 
-  callback(null, sessionId);
+  callback(null, null, sessionId);
 };
 
 // Generate UUID v4

--- a/test/unit/connection.test.js
+++ b/test/unit/connection.test.js
@@ -112,10 +112,9 @@ describe('JSTP Connection', () => {
         constants.TEST_USERNAME, constants.TEST_PASSWORD, callback);
 
       const handshakeRequest = {
-        handshake: [0, constants.TEST_APPLICATION]
+        handshake: [0, constants.TEST_APPLICATION],
+        login: [constants.TEST_USERNAME, constants.TEST_PASSWORD]
       };
-
-      handshakeRequest[constants.TEST_USERNAME] = constants.TEST_PASSWORD;
 
       expect(clientTransportMock.send)
         .to.be.called.with(jstp.stringify(handshakeRequest));
@@ -193,9 +192,8 @@ describe('JSTP Connection', () => {
 
       const packet = {
         handshake: [0, constants.TEST_APPLICATION],
+        login: [constants.TEST_USERNAME, constants.TEST_PASSWORD]
       };
-
-      packet[constants.TEST_USERNAME] = constants.TEST_PASSWORD;
 
       serverTransportMock.emitPacket(packet);
 
@@ -205,8 +203,8 @@ describe('JSTP Connection', () => {
       }));
 
       expect(startSessionSpy).to.have.been.called.with(
-        serverConnection, applicationMock,
-        constants.TEST_USERNAME, constants.TEST_PASSWORD);
+        serverConnection, applicationMock, 'login',
+        [constants.TEST_USERNAME, constants.TEST_PASSWORD]);
 
       sendSpy.reset();
       startSessionSpy.reset();
@@ -217,13 +215,11 @@ describe('JSTP Connection', () => {
       const startSessionSpy =
         chai.spy.on(serverMock, 'startSession');
 
+      const password = 'illegal password';
       const packet = {
         handshake: [0, constants.TEST_APPLICATION],
+        login: [constants.TEST_USERNAME, password]
       };
-
-      const password = 'illegal password';
-
-      packet[constants.TEST_USERNAME] = password;
 
       serverTransportMock.emitPacket(packet);
 
@@ -233,7 +229,8 @@ describe('JSTP Connection', () => {
       }));
 
       expect(startSessionSpy).to.have.been.called.with(
-        serverConnection, applicationMock, constants.TEST_USERNAME, password);
+        serverConnection, applicationMock, 'login',
+        [constants.TEST_USERNAME, password]);
 
       sendSpy.reset();
       startSessionSpy.reset();

--- a/test/unit/mock/server.js
+++ b/test/unit/mock/server.js
@@ -32,16 +32,28 @@ ServerMock.prototype.getClients = function() {
 ServerMock.prototype.broadcast = function() { };
 
 ServerMock.prototype.startSession =
-  function(connection, application, username, password, callback) {
+  function(connection, application, strategy, credentials, callback) {
     if (application.name !== constants.TEST_APPLICATION) {
       return callback(new jstp.RemoteError(jstp.ERR_APP_NOT_FOUND));
     }
 
-    if (username &&
-        (username !== constants.TEST_USERNAME ||
-         password !== constants.TEST_PASSWORD)) {
-      return callback(new jstp.RemoteError(jstp.ERR_AUTH_FAILED));
+    let username = null;
+    let success = false;
+
+    if (strategy === 'anonymous') {
+      success = true;
     }
 
-    callback(null, constants.TEST_SESSION_ID);
+    if (strategy === 'login' &&
+        credentials[0] === constants.TEST_USERNAME &&
+        credentials[1] === constants.TEST_PASSWORD) {
+      success = true;
+      username = constants.TEST_USERNAME;
+    }
+
+    if (success) {
+      callback(null, username, constants.TEST_SESSION_ID);
+    } else {
+      callback(new jstp.RemoteError(jstp.ERR_AUTH_FAILED));
+    }
   };


### PR DESCRIPTION
* Introduce the concept of authentication strategies.
* Implement `login` and `anonymous` strategies.
* Make handshake packets include the strategy as an action field.
* Update tests.
* Update docs.

Refs: https://github.com/metarhia/JSTP/issues/35#issuecomment-277692315

See more details about the implementation in the updated `doc/protocol.md`.