### PR TITLE
doc: document protocol versioning policy

### DIFF
--- a/doc/VERSIONING.md
+++ b/doc/VERSIONING.md
@@ -1,5 +1,7 @@
 # Versioning
 
+## Package versioning
+
 When we reach 1.0, we will just adhere to [semantic
 versioning](http://semver.org/) strictly, but semver says nothing about
 versions `<1.0.0`. Thus we extend semver's rules applying them to these
@@ -10,3 +12,18 @@ a feature or a bugfix.
 Accordingly, if labels named `semver-major` or `semver-minor` are added to any
 issue or pull request before we have released `v1.0.0`, they actually assume
 minor and patch subversions.
+
+## Protocol versioning
+
+Before the package reaches version 1.0.0, the protocol version is bound to the
+first of the `metarhia-jstp` package versions that implement the same
+specification of the protocol. It would be nice to have it versioned
+independently, but it's too late to do it, since we haven't been versioning it
+from the beginning and we have made changes to the specification multiple
+times.
+
+When the package reaches 1.0.0, the protocol version will be unconditionally
+bumped to 1.0.0 too, regardless of whether `metarhia-jstp@1.0.0` brings any
+changes to the protocol.  We will then take this as a starting point and the
+protocol specification will be versioned with semver independently from the
+package.


### PR DESCRIPTION
In order to communicate with developers of alternative implementations and be reasonable about compatibility, we need to assign versions to the protocol too. This PR documents the protocol versioning policy (see details in the changed file).

According to this proposal, e.g., the current version of the protocol is 0.5 and the next one, if #54 lands, is 0.7.

@tshemsedinov, @belochub, do you agree with this proposal or you have other ideas about how we must assign versions to the protocol?