### PR TITLE
server: clean internal structures on close

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -72,6 +72,9 @@ Server.prototype.close = function() {
     const connection = this.clients[cid];
     connection.close();
   });
+
+  this.clients = {};
+  this._cachedClientsArray = [];
 };
 
 // Get all clients as an array of JSTP connection instances


### PR DESCRIPTION
After server has been closed, clean internal structures such as `Server#clients` and `Server#_cachedClientsArray`.