### PR TITLE
parser: make parser single-pass

### DIFF
--- a/src/jsrs_parser.h
+++ b/src/jsrs_parser.h
@@ -19,11 +19,8 @@ v8::Local<v8::Value> Parse(v8::Isolate* isolate,
 
 namespace internal {
 
-// Prepares a source string for parsing throwing out whitespace and comments.
-const char* PrepareString(v8::Isolate* isolate,
-                          const char*  str,
-                          std::size_t  length,
-                          std::size_t* new_length);
+// Returns count of bytes needed to skip to next token.
+size_t SkipToNextToken(const char* str, const char* end);
 
 // Parses an undefined value from `begin` but never past `end` and returns the
 // parsed JavaScript value. The `size` is incremented by the number of


### PR DESCRIPTION
* Eliminate `jstp::parser::internal::PrepareString` function thus avoiding extra memory copying.
* Fix deleting comment blocks located inside of strings.
* Fix key parsing not throwing error when it included spaces but was not enclosed in quotes.

Fixes: #60