### PR TITLE
parser: remove special case for '\0' literal

### DIFF
--- a/src/jsrs_parser.cc
+++ b/src/jsrs_parser.cc
@@ -452,10 +452,6 @@ static char* GetControlChar(Isolate*    isolate,
       *result = '\v';
       break;
     }
-    case '0': {
-      *result = '\0';
-      break;
-    }
 
     case 'x': {
       *result = ReadHexNumber(str + 1, 2, &ok);


### PR DESCRIPTION
Remove special case for '\0' in control character parsing.