### PR TITLE
doc: update badges in README.md and doc/index.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-[![TravisCI](https://img.shields.io/travis/metarhia/JSTP.svg?branch=master&style=flat-square)](https://travis-ci.org/metarhia/JSTP)
-[![bitHound](https://img.shields.io/bithound/dependencies/github/metarhia/JSTP.svg?style=flat-square)](https://www.bithound.io/github/metarhia/JSTP)
-[![NPM Version](https://img.shields.io/npm/v/metarhia-jstp.svg?style=flat-square)](https://www.npmjs.com/package/metarhia-jstp)
-[![NPM Downloads/Month](https://img.shields.io/npm/dm/metarhia-jstp.svg?style=flat-square)](https://www.npmjs.com/package/metarhia-jstp)
-[![NPM Downloads](https://img.shields.io/npm/dt/metarhia-jstp.svg?style=flat-square)](https://www.npmjs.com/package/metarhia-jstp)
+[![Travis CI](https://travis-ci.org/metarhia/JSTP.svg?branch=master)](https://travis-ci.org/metarhia/JSTP)
+[![bitHound Dependencies](https://www.bithound.io/github/metarhia/JSTP/badges/dependencies.svg)](https://www.bithound.io/github/metarhia/JSTP/master/dependencies/npm)
+[![bitHound Score](https://www.bithound.io/github/metarhia/JSTP/badges/score.svg)](https://www.bithound.io/github/metarhia/JSTP)
+[![NPM Version](https://badge.fury.io/js/metarhia-jstp.svg)](https://badge.fury.io/js/metarhia-jstp)
+[![NPM Downloads/Month](https://img.shields.io/npm/dm/metarhia-jstp.svg)](https://www.npmjs.com/package/metarhia-jstp)
+[![NPM Downloads](https://img.shields.io/npm/dt/metarhia-jstp.svg)](https://www.npmjs.com/package/metarhia-jstp)
 
 # JSTP / JavaScript Transfer Protocol
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,8 +1,11 @@
 # JSTP / JavaScript Transfer Protocol
 
-[![Build Status](https://travis-ci.org/metarhia/JSTP.svg?branch=master)](https://travis-ci.org/metarhia/JSTP)
-[![Dependency Status](https://david-dm.org/metarhia/JSTP.svg)](https://david-dm.org/metarhia/JSTP)
-[![DevDependency Status](https://david-dm.org/metarhia/JSTP/dev-status.svg)](https://david-dm.org/metarhia/JSTP)
+[![Travis CI](https://travis-ci.org/metarhia/JSTP.svg?branch=master)](https://travis-ci.org/metarhia/JSTP)
+[![bitHound Dependencies](https://www.bithound.io/github/metarhia/JSTP/badges/dependencies.svg)](https://www.bithound.io/github/metarhia/JSTP/master/dependencies/npm)
+[![bitHound Score](https://www.bithound.io/github/metarhia/JSTP/badges/score.svg)](https://www.bithound.io/github/metarhia/JSTP)
+[![NPM Version](https://badge.fury.io/js/metarhia-jstp.svg)](https://badge.fury.io/js/metarhia-jstp)
+[![NPM Downloads/Month](https://img.shields.io/npm/dm/metarhia-jstp.svg)](https://www.npmjs.com/package/metarhia-jstp)
+[![NPM Downloads](https://img.shields.io/npm/dt/metarhia-jstp.svg)](https://www.npmjs.com/package/metarhia-jstp)
 
 ## Installation
 


### PR DESCRIPTION
Travis CI and bitHound badges in `README.md` are now included directly.
NPM badges are left with <shields.io> since there are no official badges
from NPM itself and these were generated by <shields.io>, not included
from an external service. Yet their style is changed to match the first
two ones.  Badges in `doc/index.md` are now synchronized with badges in
`README.md` since they weren't updated last time when they were changed
in `README.md`.

Refs: https://github.com/metarhia/Metarhia/issues/3

Pro: more stable badge loading.
Con: badges aren't flat anymore.