### PR TITLE
lib: fix behavior with util.inspect

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -13,6 +13,11 @@ module.exports = Connection;
 
 let nextConnectionId = 0;
 
+// Mapping of packet types to handler function names (forward declaration, see
+// definition below the Connection class).
+//
+let PACKET_HANDLERS;  // eslint-disable-line prefer-const
+
 // JSTP connection class
 //   transport - an abstract socket
 //   server - JSTP server instance, used only for server-side parts
@@ -324,7 +329,7 @@ Connection.prototype._processPacket = function(packet) {
     return;
   }
 
-  const handler = Connection.PACKET_HANDLERS[kind];
+  const handler = PACKET_HANDLERS[kind];
   if (handler) {
     handler.call(this, packet, keys);
   } else {
@@ -619,9 +624,7 @@ Connection.prototype._emitPacketEvent = function(kind, packet, packetId, args) {
   this.emit(kind, eventArgs);
 };
 
-// Mapping of packet types to handler function names
-//
-Connection.PACKET_HANDLERS = {
+PACKET_HANDLERS = {
   handshake: Connection.prototype._processHandshakePacket,
   call:      Connection.prototype._processCallPacket,
   callback:  Connection.prototype._processCallbackPacket,


### PR DESCRIPTION
If one tried to print the result of `require('metarhia-jstp')` in general or the `Connection` class itself to console, it resulted in invocation of internal logic of the `Connection` and crashing with an exception.

A similar issue had been fixed in f7c393b0171a63b6e428b72c5ecb381635714376 and 76e4323ebb375737a777b317d250ec566692e03e but was introduced again in 4a7941acb81449c1febd51ab1d6270636e43fe99.