### PR TITLE
deps,build: update webpack to 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "remark-cli": "^2.1.0",
     "remark-lint": "^5.4.0",
     "remark-validate-links": "^5.0.0",
-    "webpack": "^1.14.0"
+    "webpack": "^2.2.1"
   },
   "scripts": {
     "test": "npm run test-unit && npm run test-integration && npm run lint",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,32 +19,22 @@ module.exports = {
     library: ['api', 'jstp']
   },
   module: {
-    loaders: [{
+    rules: [{
       test: /\.js$/,
-      loader: 'babel-loader?cacheDirectory=true'
+      loader: 'babel-loader',
+      options: {
+        cacheDirectory: true
+      }
     }]
   },
   devtool: 'source-map',
-  node: {
-    Buffer: true,
-  },
   bail: true,
   plugins: [
-    new webpack.optimize.OccurenceOrderPlugin(),
-    new webpack.optimize.DedupePlugin(),
     new webpack.optimize.UglifyJsPlugin({
-      compressor: {
-        screw_ie8: true,  // eslint-disable-line camelcase
-        warnings: false
-      },
-      mangle: {
-        screw_ie8: true  // eslint-disable-line camelcase
-      },
-      output: {
-        comments: false,
-        screw_ie8: true  // eslint-disable-line camelcase
-      }
+      sourceMap: true
     }),
-    new webpack.BannerPlugin(license)
+    new webpack.BannerPlugin({
+      banner: license
+    })
   ]
 };


### PR DESCRIPTION
This PR updates webpack to the next major version.

* Update the `devDependency` field in `package.json`.
* Use the new loaders config syntax.
* Drop obsolete plugins.
* Remove the options that are now enabled by default.
* Together with the previous change, remove the options that have been
  enabled by default in webpack 1.x too.