### PR TITLE
build,test: don't recompile sources from scratch

### DIFF
--- a/build-native.js
+++ b/build-native.js
@@ -6,29 +6,36 @@ const childProcess = require('child_process');
 const EXIT_SUCCESS = 0;
 const EXIT_FAIL = 1;
 
-const nodeGyp = childProcess.spawn('node-gyp', ['rebuild'], { shell: true });
-const errorLines = [];
+let action = process.argv.includes('--rebuild') ? 'rebuild' : 'build';
 
-nodeGyp.on('error', () => {
-  handleBuildError(EXIT_FAIL);
-});
-
-nodeGyp.stdout.pipe(process.stdout);
-
-nodeGyp.stderr.on('data', (data) => {
-  const line = data.toString();
-  console.error(line);
-  errorLines.push(line);
-});
-
-nodeGyp.on('exit', (code) => {
-  if (errorLines.length > 0) {
-    fs.writeFileSync('builderror.log', errorLines.join('\n'));
+fs.access('build', (error) => {
+  if (error) {
+    action = 'rebuild';
   }
-  if (code !== EXIT_SUCCESS) {
-    handleBuildError(code);
-  }
-  process.exit();
+
+  const nodeGyp = childProcess.spawn('node-gyp', [action], { shell: true });
+  const errorLines = [];
+
+  nodeGyp.on('error', () => {
+    handleBuildError(EXIT_FAIL);
+  });
+
+  nodeGyp.stdout.pipe(process.stdout);
+
+  nodeGyp.stderr.on('data', (data) => {
+    const line = data.toString();
+    console.error(line);
+    errorLines.push(line);
+  });
+
+  nodeGyp.on('exit', (code) => {
+    if (errorLines.length > 0) {
+      fs.writeFileSync('builderror.log', errorLines.join('\n'));
+    }
+    if (code !== EXIT_SUCCESS) {
+      handleBuildError(code);
+    }
+  });
 });
 
 function handleBuildError(code) {

--- a/package.json
+++ b/package.json
@@ -62,9 +62,10 @@
     "test-integration": "node test/integration/run-tests",
     "test-browser-unit": "karma start",
     "lint": "eslint . && remark .",
-    "install": "npm run build-node",
+    "install": "npm run rebuild-node",
     "build": "npm run build-node && npm run build-browser",
     "build-node": "node build-native",
+    "rebuild-node": "node build-native --rebuild",
     "build-browser": "webpack --progress --colors",
     "prepublish": "npm run build-browser",
     "pretest": "npm run build-node"


### PR DESCRIPTION
`node-gyp rebuild` used to be invoked before each `npm test`. It slowed
down tests and forced CI to recompile the sources twice before doing
anything. Now `node-gyp build` is run before tests if the `build`
directory is present (otherwise it still runs `node-gyp rebuild` so
that you can do `rm -r build && npm test` if you want to).

Changes to npm scripts:

  * `npm run build-node` now runs `node-gyp build` instead of
    `node-gyp rebuild`.
  * New script `npm run rebuild-node` forces `node-gyp rebuild`.