### PR TITLE
server: don't allow invalid packets to crash server

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -311,6 +311,7 @@ Connection.prototype._onSocketClose = function() {
 //   error - error that has occured
 //
 Connection.prototype._onSocketError = function(error) {
+  this._end();
   this.emit('error', error, this);
 };
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -95,6 +95,10 @@ Server.prototype._onRawConnection = function(socket) {
   const connection = new Connection(
     this.rawServer.createTransport(socket), this);
 
+  connection.on('error', (error) => {
+    this.emit('connectionError', error, connection);
+  });
+
   connection.setTimeout(HANDSHAKE_TIMEOUT, () => {
     if (!connection.handshakeDone) {
       connection.close();
@@ -111,10 +115,6 @@ Server.prototype._onRawConnection = function(socket) {
 Server.prototype._onClientConnect = function(connection) {
   this.clients[connection.id] = connection;
   this._cachedClientsArray.push(connection);
-
-  connection.on('error', (error) => {
-    this.emit('connectionError', error, connection);
-  });
 };
 
 // Client connection close event handler


### PR DESCRIPTION
This commit fixes a critical issue that allowed to crash the server
with an unhandled error event sending an invalid packet that causes
parser error before a handshake.

Fixes: https://github.com/metarhia/JSTP/issues/76