### PR TITLE
doc: fix linter warning in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Notable changes:
    *(Alexey Orlenko)*
    [#78](https://github.com/metarhia/JSTP/pull/78)
 
-
 All changes:
 
  * **server:** clean internal structures on close


### PR DESCRIPTION
Remove an extra consecutive blank line in `CHANGELOG.md`.