### PR TITLE
tools: remove crlf.js from .*ignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ node_modules
 *.heapsnapshot
 
 # Development helpers
-crlf.js
 dev/
 
 # Project files

--- a/.npmignore
+++ b/.npmignore
@@ -4,7 +4,6 @@
 *.heapsnapshot
 
 # Development helpers
-crlf.js
 dev/
 
 # Project files


### PR DESCRIPTION
This entry was copied from .gitignore file of Impress (as the whole file
was copied) at some time in the beginning of the project.  I guess, it
had been used by @tshemsedinov long time ago, but now Impress itself
doesn't have such entry in its ignore-files.

The next step will be to review my `dev/` directory, remove the helpers
that I don't need anymore and refactor the rest of them to publicly
available tests and tools to be placed in the corresponding directories
of the repository.