### PR TITLE
socket: use socket.destroy() properly

### DIFF
--- a/lib/transport.socket.js
+++ b/lib/transport.socket.js
@@ -208,8 +208,6 @@ SocketTransport.prototype.end = function(data) {
   } else {
     this.socket.end();
   }
-
-  this.socket.destroy();
 };
 
 // Socket data handler
@@ -222,7 +220,7 @@ SocketTransport.prototype._onSocketData = function(chunk) {
   try {
     this._buffer = jsrs.parseNetworkPackets(this._buffer, packets);
   } catch (error) {
-    this.emit('error', error);
+    this.socket.destroy(error);
     return;
   }
 

--- a/lib/transport.ws.js
+++ b/lib/transport.ws.js
@@ -101,8 +101,7 @@ function JstpWebSocketServer(httpServer, config,
     'listening',
     'close'
   ]);
-
-  this.httpServer.on('clientError', this._onSocketError.bind(this));
+  common.forwardEvent(httpServer, this, 'clientError', 'error');
 
   this.wsServer = new WebSocketServer(this.config);
   this.wsServer.on('request', this._onRequest.bind(this));
@@ -145,13 +144,6 @@ JstpWebSocketServer.prototype._onRequest = function(request) {
     request.accept(constants.WEBSOCKET_PROTOCOL_NAME, request.origin);
 
   this.emit('connection', connection);
-};
-
-// Socket error handler
-//
-JstpWebSocketServer.prototype._onSocketError = function(error, socket) {
-  socket.destroy();
-  this.emit('error', error);
 };
 
 // Default originCheckStrategy value for ws.createClient and


### PR DESCRIPTION
`socket.destroy()` should only be called in case of application errors
that make it impossible to continue working with this socket (like
protocol parsing errors, exactly our situation). This method emits
`error` event on socket automatically if an exception is passed as the
first argument.