### PR TITLE
tools,meta: make AUTHORS reflect all the contributors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,4 @@
 Timur Shemsedinov <timur.shemsedinov@gmail.com>
 Alexey Orlenko <eaglexrlnk@gmail.com>
 Mykola Bilochub <nbelochub@gmail.com>
+Vlad Dziuba <dzyubavlad@gmail.com> <Dzyubavlad@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,4 +1,5 @@
 Timur Shemsedinov <timur.shemsedinov@gmail.com>
 Alexey Orlenko <eaglexrlnk@gmail.com>
 Mykola Bilochub <nbelochub@gmail.com>
+Dmitry Borisov <dimon.durak@gmail.com> <Dimon Durak>
 Vlad Dziuba <dzyubavlad@gmail.com> <Dzyubavlad@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+Timur Shemsedinov <timur.shemsedinov@gmail.com>
+Alexey Orlenko <eaglexrlnk@gmail.com>
+Mykola Bilochub <nbelochub@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,5 @@
-Timur Shemsedinov <timur.shemsedinov@gmail.com>
 Alexey Orlenko <eaglexrlnk@gmail.com>
-Mykola Bilochub <nbelochub@gmail.com>
 Dmitry Borisov <dimon.durak@gmail.com> <Dimon Durak>
+Mykola Bilochub <nbelochub@gmail.com>
+Timur Shemsedinov <timur.shemsedinov@gmail.com>
 Vlad Dziuba <dzyubavlad@gmail.com> <Dzyubavlad@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,5 @@
 Timur Shemsedinov <timur.shemsedinov@gmail.com>
-Dimon Durak <Dimon Durak>
+Dmitry Borisov <dimon.durak@gmail.com>
 Artem Chernenkiy <notthewhite@gmail.com>
 Alexey Orlenko <eaglexrlnk@gmail.com>
 Mykola Bilochub <nbelochub@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,6 @@
 Timur Shemsedinov <timur.shemsedinov@gmail.com>
+Dimon Durak <Dimon Durak>
+Artem Chernenkiy <notthewhite@gmail.com>
 Alexey Orlenko <eaglexrlnk@gmail.com>
 Mykola Bilochub <nbelochub@gmail.com>
+Vlad <Dzyubavlad@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -3,4 +3,4 @@ Dimon Durak <Dimon Durak>
 Artem Chernenkiy <notthewhite@gmail.com>
 Alexey Orlenko <eaglexrlnk@gmail.com>
 Mykola Bilochub <nbelochub@gmail.com>
-Vlad <Dzyubavlad@gmail.com>
+Vlad Dziuba <dzyubavlad@gmail.com>

--- a/LICENSE
+++ b/LICENSE
@@ -3,9 +3,8 @@ JavaScript Transfer Protocol ("JSTP") is licensed for use as follows:
 """
 MIT License
 
-Copyright (c) 2016–2017 JSTP project authors
-(see https://github.com/metarhia/JSTP/blob/master/AUTHORS for full list)
-and other JSTP contributors.
+Copyright (c) 2016–2017 JSTP contributors
+(see https://github.com/metarhia/JSTP/blob/master/AUTHORS).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tools/common.js
+++ b/tools/common.js
@@ -1,0 +1,27 @@
+// Common utilities used by tools
+'use strict';
+
+const childProcess = require('child_process');
+const fs = require('fs');
+
+const common = {};
+module.exports = common;
+
+common.getCommandOutput = (cmd) => {
+  const exec = common.promisify(childProcess.exec);
+  return exec(cmd).then((stdout, stderr) => {
+    if (stderr) console.error(stderr);
+    return stdout;
+  });
+};
+
+common.promisify = (fn) => (...args) => (
+  new Promise((resolve, reject) => {
+    fn(...args, (error, ...result) => {
+      if (error) reject(error);
+      else resolve(...result);
+    });
+  })
+);
+
+common.writeFile = common.promisify(fs.writeFile);

--- a/tools/prepare-release.js
+++ b/tools/prepare-release.js
@@ -2,10 +2,10 @@
 
 'use strict';
 
-const childProcess = require('child_process');
-const fs = require('fs');
 const https = require('https');
 const path = require('path');
+
+const { getCommandOutput, writeFile } = require('./common');
 
 const commandName = path.relative('.', __filename);
 const help = `\
@@ -82,14 +82,6 @@ getCommandOutput('git cherry ' + branch).then((cherryOut) => {
   console.error(message);
   process.exit(1);
 });
-
-function getCommandOutput(cmd) {
-  const exec = promisify(childProcess.exec);
-  return exec(cmd).then((stdout, stderr) => {
-    if (stderr) console.error(stderr);
-    return stdout;
-  });
-}
 
 function getMetadata(commitHash) {
   const command = 'git log --format="%aN%n%B" -n 1 ' + commitHash;
@@ -188,17 +180,6 @@ function getStreamData(stream, callback) {
   stream.on('error', callback);
 }
 
-function promisify(fn) {
-  return (...args) => (
-    new Promise((resolve, reject) => {
-      fn(...args, (error, ...result) => {
-        if (error) reject(error);
-        else resolve(...result);
-      });
-    })
-  );
-}
-
 function processCommits(commits) {
   commits = filterCommits(commits, maxLevel);
 
@@ -233,7 +214,6 @@ function processCommits(commits) {
 
   script += '\n';
 
-  const writeFile = promisify(fs.writeFile);
   return Promise.all([
     writeFile(`${branch}-apply-commits.sh`, script),
     writeFile(`${branch}-commits.md`, changelog)

--- a/tools/update-authors.js
+++ b/tools/update-authors.js
@@ -8,14 +8,12 @@ const { getCommandOutput, writeFile } = require('./common');
 const AUTHORS_PATH = path.resolve(__dirname, '..', 'AUTHORS');
 
 getCommandOutput('git log --reverse --format="%aN <%aE>"').then((out) => {
-  const seen = new Set();
-  const authors = out.split('\n').reduce((list, author) => {
-    if (!seen.has(author)) {
-      list.push(author);
-      seen.add(author);
+  const authors = [];
+  for (const author of out.split('\n')) {
+    if (!authors.includes(author)) {
+      authors.push(author);
     }
-    return list;
-  }, []);
+  }
   return writeFile(AUTHORS_PATH, authors.join('\n'));
 }).catch((error) => {
   const message = error.stack || error.toString();

--- a/tools/update-authors.js
+++ b/tools/update-authors.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const path = require('path');
+const { getCommandOutput, writeFile } = require('./common');
+
+const AUTHORS_PATH = path.resolve(__dirname, '..', 'AUTHORS');
+
+getCommandOutput('git log --reverse --format="%aN <%aE>"').then((out) => {
+  const seen = new Set();
+  const authors = out.split('\n').reduce((list, author) => {
+    if (!seen.has(author)) {
+      list.push(author);
+      seen.add(author);
+    }
+    return list;
+  }, []);
+  return writeFile(AUTHORS_PATH, authors.join('\n'));
+}).catch((error) => {
+  const message = error.stack || error.toString();
+  console.error(message);
+  process.exit(1);
+});


### PR DESCRIPTION
Right now we only have those who have made valuable contributions noted in the AUTHORS file. But there are people who have made minor contributions, like fixing typos, updating the links and such, to examples and README.md (which is effectively a part of documentation, and documentation is a part of the software, according to the MIT license). And however small their contributions may be, these are still contributions and it is fair to add those people to the AUTHORS file.

Additionally, the process of updating this file is now automated.

#### Changes:

* Add new `update-authors.js` tool that traverses commit history using `git log` and creates authors list.
* Decouple common functions into a module shared between tools.
* Add `.mailmap` file with proper names and emails of active collaborators.  This file is automatically parsed by Git so that `git log --format='%aN <%aE>'` won't show duplicate entries in case something was committed with misconfigured Git.  E.g., without this file @tshemsedinov appears twice in the list, as Timur Shemsedinov and as tshemsedinov, but with mailmap applied Git automatically coalesces these entries to use the full name only.
* Update the list using `tools/update-authors.js`.