### PR TITLE
w3c-ws: fix invalid property access

### DIFF
--- a/lib/transport.ws.browser.js
+++ b/lib/transport.ws.browser.js
@@ -82,11 +82,9 @@ W3CWebSocketClient.prototype.connect = function(callback) {
 //
 W3CWebSocketClient.prototype.disconnect = function(callback) {
   transportCommon.ensureClientConnected(this);
-
   if (callback) {
-    this.connection.once('close', callback);
+    this.socketEventEmitter.once('close', callback);
   }
-
   this.socket.close();
 };
 


### PR DESCRIPTION
s/connection/socketEventEmitter