### PR TITLE
connection: change style of a forward declaration

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -16,7 +16,7 @@ let nextConnectionId = 0;
 // Mapping of packet types to handler function names (forward declaration, see
 // definition below the Connection class).
 //
-let PACKET_HANDLERS;  // eslint-disable-line prefer-const
+let PACKET_HANDLERS = null;
 
 // JSTP connection class
 //   transport - an abstract socket


### PR DESCRIPTION
ESLint complains that a variable is never reassigned if it is declared
like this:

```js
let variable;
...
variable = value;
```

Because of this, we had a forward declaration in `connection.js` marked
with a directive for ESLint to ignore the line. This commit changes it
to assignment to null.