### PR TITLE
connection: introduce the concept of states

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -13,6 +13,17 @@ module.exports = Connection;
 
 let nextConnectionId = 0;
 
+// Connection states. Connection.STATES is a public API reference to this
+// enumeration.
+//
+const CONN_STATES = Object.assign(Object.create(null), {
+  AWAITING_HANDSHAKE: Symbol('Awaiting handshake'),
+  NORMAL:             Symbol('Normal'),
+  AWAITING_RECONNECT: Symbol('Awaiting reconnection'),
+  CLOSING:            Symbol('Closing'),
+  CLOSED:             Symbol('Closed')
+});
+
 // Mapping of packet types to handler function names (forward declaration, see
 // definition below the Connection class).
 //
@@ -33,6 +44,7 @@ function Connection(transport, server, client) {
   this.transport = transport;
   this.server = server;
   this.client = client;
+  this.state = CONN_STATES.AWAITING_HANDSHAKE;
 
   this.id = nextConnectionId++;
   this._nextPacketId = 0;
@@ -49,7 +61,6 @@ function Connection(transport, server, client) {
 
   this._callbacks = {};
 
-  this.handshakeDone = false;
   this.username = null;
   this.sessionId = null;
 
@@ -64,6 +75,8 @@ function Connection(transport, server, client) {
 }
 
 util.inherits(Connection, events.EventEmitter);
+
+Connection.STATES = CONN_STATES;
 
 // Send a call packet over the connection
 //   interfaceName - name of an interface
@@ -247,7 +260,7 @@ Connection.prototype.createPacket = function(kind, target, verb, args) {
 // Close the connection
 //
 Connection.prototype.close = function() {
-  this.stopHeartbeat();
+  this._prepareClose();
   this.transport.end();
 };
 
@@ -287,7 +300,7 @@ Connection.prototype._send = function(packet) {
 //   packet - a packet to send (optional)
 //
 Connection.prototype._end = function(packet) {
-  this.stopHeartbeat();
+  this._prepareClose();
 
   if (packet) {
     const data = jsrs.stringify(packet);
@@ -301,6 +314,7 @@ Connection.prototype._end = function(packet) {
 //
 Connection.prototype._onSocketClose = function() {
   this.stopHeartbeat();
+  this.state = CONN_STATES.CLOSED;
   this.emit('close', this);
   if (this.server) {
     this.server.emit('disconnect', this);
@@ -325,7 +339,8 @@ Connection.prototype._processPacket = function(packet) {
   }
 
   const kind = keys[0];
-  if (!this.handshakeDone && kind !== 'handshake') {
+  if (this.state === CONN_STATES.AWAITING_HANDSHAKE &&
+      kind !== 'handshake') {
     this._rejectPacket(packet, true);
     return;
   }
@@ -355,7 +370,7 @@ Connection.prototype._rejectPacket = function(packet, fatal) {
 //   keys - array of packet keys
 //
 Connection.prototype._processHandshakePacket = function(packet, keys) {
-  if (this.handshakeDone) {
+  if (this.state !== CONN_STATES.AWAITING_HANDSHAKE) {
     this._rejectPacket(packet, true);
     return;
   }
@@ -413,7 +428,7 @@ Connection.prototype._onSessionCreated = function(error, username, sessionId) {
   }
 
   this.username = username;
-  this.handshakeDone = true;
+  this.state = CONN_STATES.NORMAL;
   this.sessionId = sessionId;
 
   this.emit('client', sessionId, this);
@@ -437,7 +452,7 @@ Connection.prototype._processHandshakeResponse = function(packet) {
   if (packet.ok) {
     delete this._callbacks[packetId];
 
-    this.handshakeDone = true;
+    this.state = CONN_STATES.NORMAL;
     this.application = this.client.application;
 
     this._emitPacketEvent('handshake', packet, packetId, {
@@ -447,7 +462,9 @@ Connection.prototype._processHandshakeResponse = function(packet) {
     callback(null, packet.ok);
   } else if (packet.error) {
     delete this._callbacks[packetId];
+    this._prepareClose();
     callback(errors.RemoteError.fromJstpArray(packet.error));
+    this.transport.end();
   } else {
     this._rejectPacket(packet, true);
   }
@@ -623,6 +640,15 @@ Connection.prototype._emitPacketEvent = function(kind, packet, packetId, args) {
   }
 
   this.emit(kind, eventArgs);
+};
+
+Connection.prototype._prepareClose = function() {
+  if (this.state === CONN_STATES.CLOSING ||
+      this.state === CONN_STATES.CLOSED) {
+    return;
+  }
+  this.state = CONN_STATES.CLOSING;
+  this.stopHeartbeat();
 };
 
 PACKET_HANDLERS = {

--- a/lib/server.js
+++ b/lib/server.js
@@ -100,7 +100,7 @@ Server.prototype._onRawConnection = function(socket) {
   });
 
   connection.setTimeout(HANDSHAKE_TIMEOUT, () => {
-    if (!connection.handshakeDone) {
+    if (connection.state !== Connection.STATES.NORMAL) {
       connection.close();
       this.emit('handshakeTimeout', connection);
     } else if (this.heartbeatInterval) {

--- a/test/unit/connection.test.js
+++ b/test/unit/connection.test.js
@@ -14,6 +14,8 @@ const ClientMock = require('./mock/client');
 const expect = chai.expect;
 chai.use(chaiSpies);
 
+const { NORMAL: STATE_NORMAL, CLOSING: STATE_CLOSING } = jstp.Connection.STATES;
+
 describe('JSTP Connection', () => {
   let serverTransportMock;
   let clientTransportMock;
@@ -74,7 +76,7 @@ describe('JSTP Connection', () => {
         expect(sessionId).to.equal(constants.TEST_SESSION_ID);
 
         expect(clientConnection.username).to.be.null;
-        expect(clientConnection.handshakeDone).to.be.true;
+        expect(clientConnection.state).to.equal(STATE_NORMAL);
 
         clientTransportMock.send.reset();
       });
@@ -103,7 +105,7 @@ describe('JSTP Connection', () => {
         expect(sessionId).to.equal(constants.TEST_SESSION_ID);
 
         expect(clientConnection.username).to.eql(constants.TEST_USERNAME);
-        expect(clientConnection.handshakeDone).to.be.true;
+        expect(clientConnection.state).to.equal(STATE_NORMAL);
 
         clientTransportMock.send.reset();
       });
@@ -133,7 +135,7 @@ describe('JSTP Connection', () => {
         expect(sessionId).to.not.exist;
 
         expect(clientConnection.username).to.be.null;
-        expect(clientConnection.handshakeDone).to.be.false;
+        expect(clientConnection.state).to.equal(STATE_CLOSING);
       });
 
       clientConnection.handshake('invalidApp', 'user', 'password', callback);
@@ -151,7 +153,7 @@ describe('JSTP Connection', () => {
         expect(sessionId).to.not.exist;
 
         expect(clientConnection.username).to.be.null;
-        expect(clientConnection.handshakeDone).to.be.false;
+        expect(clientConnection.state).to.equal(STATE_CLOSING);
       });
 
       clientConnection.handshake(constants.TEST_APPLICATION,


### PR DESCRIPTION
Drop `connection.handshakeDone` property and implicit state that could
only be traced using events and callbacks in favor of explicit
connection state indicator as a property of connection.

Right now there are four used states (AWAITING_HANDSHAKE, NORMAL,
CLOSING and CLOSED) and one reserved (AWAITING_RECONNECT).

Transition diagram:

```
          +--------------------+         (timeout)
          | AWAITING_HANDSHAKE |---------------------------+
          +--------------------+                           |
                    |                                      |
                    | (handshake done)                     |
                    v                                      |
          +--------------------+  (closed intentionally)   |
  +------>|       NORMAL       |-------------------------+ |
  |       +--------------------+                         | |
  |                 |                                    | |
  |                 | (network error)                    | |
  |                 v                                    | |
  |       +--------------------+                         | |
  +-------| AWAITING_RECONNECT |                         | |
(success) +--------------------+                         | |
                    |                                    | |
                    | (timeout)                          | |
                    v                                    | |
          +--------------------+                         | |
          |      CLOSING       |<------------------------+-+
          +--------------------+
                    |
                    |
                    v
          +--------------------+
          |       CLOSED       |
          +--------------------+
```