### PR TITLE
connection: check that method arguments exist

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -475,6 +475,10 @@ Connection.prototype._processCallPacket = function(packet, keys) {
 
   const callback = this._remoteCallbackWrapper.bind(this, packetId);
 
+  if (!args) {
+    return callback(errors.ERR_INVALID_SIGNATURE);
+  }
+
   try {
     this.application.callMethod(this,
       interfaceName, methodName, args, callback);


### PR DESCRIPTION
The common implementation of `application.callMethod()` involves
checking `args.length` which leads to crash if `args` is null or
undefined.  This commit provides a quick-and-dirty patch for only
this vulnerability until the common approach for message sanity
checking will have been developed.