### PR TITLE
client: drop redundant callback argument

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -83,12 +83,12 @@ Client.prototype.connectAndHandshake = function(
       return callback(error);
     }
 
-    connection.handshake(appName, username, password, (error, sid) => {
+    connection.handshake(appName, username, password, (error) => {
       if (error) {
         return callback(error);
       }
 
-      callback(null, connection, sid);
+      callback(null, connection);
     });
   });
 };
@@ -107,7 +107,7 @@ Client.prototype.connectAndInspect = function(
   appName, username, password, interfaces, callback
 ) {
   this.connectAndHandshake(
-    appName, username, password, (error, connection, sid) => {
+    appName, username, password, (error, connection) => {
       if (error) {
         return callback(error);
       }
@@ -118,7 +118,7 @@ Client.prototype.connectAndInspect = function(
         if (errs) {
           api._errors = errs;
         }
-        callback(null, connection, sid, api);
+        callback(null, connection, api);
       });
 
       interfaces.forEach((interfaceName) => {

--- a/test/integration/client.js
+++ b/test/integration/client.js
@@ -38,12 +38,12 @@ wsClient.on('error', (error) => {
   common.fatal('WebSocket client error: ' + error);
 });
 
-function onConnect(client, error, connection, sessionId, api) {
+function onConnect(client, error, connection, api) {
   if (error) {
     common.fatal('Could not connect: ' + error);
   }
 
-  console.log('Connected, session ID is', sessionId);
+  console.log('Connected, session ID is', connection.sessionId);
 
   connection.on('error', (error) => {
     common.fatal('Connection error: ' +  error);


### PR DESCRIPTION
This commit removes the sessionId argument of client.connectAndHandshake() and client.connectAndInspect(). It is not needed since the connection is passed, and the session id is
available as a property of the connection.

Fixes: https://github.com/metarhia/JSTP/issues/58