### PR TITLE
client: handle errors in connectAndInspect

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -3,8 +3,6 @@
 const events = require('events');
 const util = require('util');
 
-const metasync = require('metasync');
-
 const apps = require('./applications');
 const common = require('./common');
 const Connection = require('./connection');
@@ -112,22 +110,28 @@ Client.prototype.connectAndInspect = function(
         return callback(error);
       }
 
-      const collector = new metasync.DataCollector(interfaces.length);
-
-      collector.on('done', (errs, api) => {
-        if (errs) {
-          api._errors = errs;
-        }
+      // DataCollector from metarhia/MetaSync is a better abstraction to do
+      // this kind of things, but there are some issues that must be resolved
+      // prior to using it here.
+      Promise.all(
+        interfaces.map((name) => new Promise((resolve, reject) => {
+          connection.inspectInterface(name, (error, proxy) => {
+            if (error) {
+              reject(error);
+            } else {
+              resolve(proxy);
+            }
+          });
+        }))
+      ).then((proxies) => {
+        const api = proxies.reduce((acc, proxy, idx) => {
+          const name = interfaces[idx];
+          acc[name] = proxy;
+          return acc;
+        }, {});
         callback(null, connection, sid, api);
-      });
-
-      interfaces.forEach((interfaceName) => {
-        connection.inspectInterface(interfaceName, (error, appInterface) => {
-          if (error) {
-            appInterface = null;
-          }
-          collector.collect(interfaceName, appInterface);
-        });
+      }).catch((error) => {
+        callback(error);
       });
     }
   );

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "./lib/simple-auth.js": false
   },
   "dependencies": {
-    "metasync": "0.1.x",
     "websocket": "^1.0.24"
   },
   "devDependencies": {


### PR DESCRIPTION
This is a backport of d8ba3fe7b9c1832ae955d2a0a5a87ff165b768ec.

As `DataCollector` always returns the data it managed to collect
successfully and passes errors as a separate object, `connectAndInspect`
has put errors as `_errors` property of the result to be consistent.
This was a horrible design decision that was counter-intuitive and would
only lead to the lack of proper error handling in application code (and
has actually led in our integration test).

Worse than that, even this `_errors` property would never have been
populated with errors because of a bug in `connectAndInspect`.

The proper solution would have been to stop inspecting interfaces as
soon as the first error occurs and return it as the first argument of
the callback.  As it turned out, it was quite tricky to do with
DataCollector, and some other issues were found while inspecting
`metasync` sources too.  Fixing these problems requires
backwards-incompatible changes and will certainly happen in the next
semver-major release of `metasync`, but we need a quick fix here.  For
this reason, the function was refactored to use promises.