### PR TITLE
Bring belochub/jstp-cli upstream

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -105,13 +105,14 @@ function _split(str, separator, limit, leaveEmpty) {
   const result = [];
   let start = 0;
 
+  // eslint-disable-next-line no-unmodified-loop-condition
   for (let i = 0; !limit || i < limit; i++) {
     const split = str.indexOf(separator, start);
     if (split === -1) break;
     if (!shouldTrim(start, split)) {
       result.push(str.slice(start, split));
-    } else {
-      limit--;
+    } else  {
+      i--;
     }
     start = split + separator.length;
   }

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,140 @@
+'use strict';
+
+// TODO: feature request: support jstp://server and jstps://server
+
+const jstp = require('.');
+const readline = require('readline');
+
+const log = console.log;
+const logErr = console.error;
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+  completer: completer
+});
+
+const state = {
+  client: null,
+  connection: null
+};
+
+const methodProcessor = {
+  call: (interfaceName, methodName, args, callback) => {
+    state.connection.callMethod(interfaceName, methodName, args.map(jstp.parse),
+        callback);
+  },
+  event: (interfaceName, eventName, args, callback) => {
+    state.connection.emitRemoteEvent(interfaceName, eventName,
+        args.map(jstp.parse));
+    callback();
+  },
+  connect: (host, port, appName, callback) => {
+    state.client = jstp.tcp.createClient({host, port, secure: true});
+    state.client.connectAndHandshake(appName, null, null,
+        (err, connection) => {
+      if (!err) state.connection = connection;
+      return callback(err)
+    });
+  },
+  disconnect: (callback) => {
+    if (state.client !== null) {
+      return state.client.disconnect(() => {
+        state.connection = null;
+        state.client = null;
+        callback();
+      });
+    }
+    callback(new Error('Not connected'));
+  }
+};
+
+function _splitArgs(token) {
+  return token && _split(token, ' $ ') || [];
+}
+
+function _split(str, separator, limit, leaveEmpty) {
+  const shouldTrim = (start, split) => !leaveEmpty && start === split;
+
+  const result = [];
+  let start = 0;
+
+  for (let i = 0; !limit || i < limit; i++) {
+    const split = str.indexOf(separator, start);
+    if (split === -1) break;
+    if (!shouldTrim(start, split)) {
+      result.push(str.slice(start, split));
+    } else {
+      limit--;
+    }
+    start = split + 1;
+  }
+  if (!shouldTrim(start, str.length)) {
+    result.push(str.slice(start));
+  }
+  return result;
+}
+
+const lineProcessor = {
+  call: (tokens, callback) => {
+    if (tokens === undefined) {
+      return callback(new Error('Not enough arguments'));
+    }
+    const args = _split(tokens, ' ', 2);
+    methodProcessor.call(args[0], args[1], _splitArgs(args[2]),
+        (err, result) => {
+      if (err) return callback(err);
+      callback(null, `Method ${args[0]}.${args[1]} returned: ` +
+        jstp.stringify(result.map(jstp.stringify)));
+    });
+  },
+  event: (tokens, callback) => {
+    if (tokens === undefined) {
+      return callback(new Error('Not enough arguments'));
+    }
+    const args = _split(tokens, ' ', 2);
+    methodProcessor.event(args[0], args[1], _splitArgs(args[2]),
+        (err) => {
+      if (err) return callback(err);
+      callback(null, `Event ${args[0]}.${args[1]} successfully emitted`);
+    });
+  },
+  connect: (tokens, callback) => {
+    if (tokens === undefined) {
+      return callback(new Error('Not enough arguments'));
+    }
+    const args = _split(tokens, ' ', 2);
+    const [host, port] = _split(args[0], ':');
+    const appName = args[1];
+    methodProcessor.connect(host, port, appName, (err) => {
+      if (err) return callback(err);
+      callback(null, 'Connection established');
+    });
+  },
+  disconnect: (_, callback) => {
+    methodProcessor.disconnect((err) => {
+      if (err) return callback('Not connected');
+      callback(null, 'Successful disconnect')
+    });
+  }
+};
+
+rl.on('line', (line) => {
+  line = line.trim();
+  const [type, leftover] = _split(line, ' ', 1);
+  lineProcessor[type](leftover, (err, result) => {
+    if (err) logErr(err);
+    else log(result);
+    rl.prompt(true);
+  });
+});
+
+function completer(line) {
+  return [[], line];
+}
+
+rl.on('SIGINT', () => {
+  rl.close();
+});
+
+rl.prompt(true);

--- a/cli.js
+++ b/cli.js
@@ -14,7 +14,7 @@ const rl = readline.createInterface({
   completer
 });
 
-const log = msg => {
+const log = (msg) => {
   const userInput = rl.line;
   if (userInput) rl.clearLine();
   console.log(msg);
@@ -58,12 +58,12 @@ const state = {
 };
 
 commandProcessor.call = (interfaceName, methodName, args, callback) => {
-  if (state.client === null) return callback(new Error('Not connected'));
+  if (!state.client) return callback(new Error('Not connected'));
   state.connection.callMethod(interfaceName, methodName, args, callback);
 };
 
 commandProcessor.event = (interfaceName, eventName, args, callback) => {
-  if (state.client === null) return callback(new Error('Not connected'));
+  if (!state.client) return callback(new Error('Not connected'));
   state.connection.emitRemoteEvent(interfaceName, eventName, args);
   callback();
 };
@@ -74,16 +74,17 @@ commandProcessor.connect = (host, port, appName, callback) => {
       (err, connection) => {
         if (err) return callback(err);
         state.connection = connection;
-        // todo make event registering generic
+        // TODO: make event registering generic
         connection.on('event', (data) => {
           log(`Received remote event: ${jstp.stringify(data)}`);
         });
         callback();
-      });
+      }
+  );
 };
 
 commandProcessor.disconnect = (callback) => {
-  if (state.client !== null) {
+  if (state.client) {
     return state.client.disconnect(() => {
       state.connection = null;
       state.client = null;
@@ -178,8 +179,8 @@ lineProcessor.disconnect = (_, callback) => {
   });
 };
 
-// map all remaining commands directly
-Object.keys(commandProcessor).map(command => {
+// Map all remaining commands directly
+Object.keys(commandProcessor).map((command) => {
   if (!lineProcessor[command]) {
     lineProcessor[command] = commandProcessor[command];
   }

--- a/cli.js
+++ b/cli.js
@@ -62,8 +62,12 @@ commandProcessor.connect = (host, port, appName, callback) => {
   state.client = jstp.tcp.createClient({ host, port, secure: true });
   state.client.connectAndHandshake(appName, null, null,
       (err, connection) => {
-        if (!err) state.connection = connection;
-        return callback(err);
+        if (err) return callback(err);
+        state.connection = connection;
+        connection.on('event', (data) => {
+          log(`Received remote event: ${jstp.stringify(data)}`);
+        });
+        callback();
       });
 };
 

--- a/cli.js
+++ b/cli.js
@@ -34,9 +34,9 @@ rl.on('line', (line) => {
   rl.prompt(true);
 });
 
-rl.on('SIGINT', () => {
-  rl.close();
-});
+rl.on('SIGINT', () => rl.close());
+
+rl.on('close', () => rl.write('exit\n'));
 
 function completer(line) {
   return [[], line];
@@ -78,9 +78,10 @@ commandProcessor.disconnect = (callback) => {
   callback(new Error('Not connected'));
 };
 
-function _splitArgs(token) {
-  return token && _split(token, ' $ ') || [];
-}
+commandProcessor.exit = () => {
+  rl.close();
+  process.exit();
+};
 
 function _split(str, separator, limit, leaveEmpty) {
   const shouldTrim = (start, split) => !leaveEmpty && start === split;
@@ -161,5 +162,12 @@ lineProcessor.disconnect = (_, callback) => {
     callback(null, 'Successful disconnect');
   });
 };
+
+// map all remaining commands directly
+Object.keys(commandProcessor).map(command => {
+  if (!lineProcessor[command]) {
+    lineProcessor[command] = commandProcessor[command];
+  }
+});
 
 rl.prompt(true);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "email": "timur.shemsedinov@gmail.com"
   },
   "main": "./jstp.js",
+  "bin": {
+    "jstp-cli": "./tools/cli.js"
+  },
   "browser": {
     "./lib/record-serialization.js": "./lib/record-serialization-fallback.js",
     "./lib/server.js": false,

--- a/tools/cli.js
+++ b/tools/cli.js
@@ -177,7 +177,7 @@ lineProcessor.connect = (tokens, callback) => {
 
 lineProcessor.disconnect = (_, callback) => {
   commandProcessor.disconnect((err) => {
-    if (err) return callback('Not connected');
+    if (err) return callback(err);
     callback(null, 'Successful disconnect');
   });
 };

--- a/tools/cli.js
+++ b/tools/cli.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 'use strict';
 
 // TODO: support jstp://server and jstps://server

--- a/tools/cli.js
+++ b/tools/cli.js
@@ -37,8 +37,8 @@ rl.on('line', (line) => {
       if (err) return log(`${err.name} occurred: ${err.message}`);
       log(result);
     });
-    rl.prompt(true);
   }
+  rl.prompt(true);
 });
 
 rl.on('SIGINT', () => {


### PR DESCRIPTION
I've created a [branch](https://github.com/metarhia/JSTP/tree/cli) to port [belochub/jstp-cli](https://github.com/belochub/jstp-cli/) to be a part of JSTP itself, as it was agreed upon in https://github.com/belochub/jstp-cli/issues/1.

Right now `cli.js` is located in the root of the project in order to mirror the original repo and make cherry-picking new commits effortless. It should later be separated into `bin/cli.js` and `lib/cli/*.js`.

/cc @belochub @lundibundi 