### PR TITLE
(v0.5 backport) connection: handle optional callbacks properly

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -82,3 +82,8 @@ common.createZeroFilledBuffer = function(size) {
 if (Buffer.alloc) {
   common.createZeroFilledBuffer = Buffer.alloc;
 }
+
+// This function can be used in contexts where a function (e.g., a callback) is
+// required but no actions have to be done.
+//
+common.doNothing = function() { };

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -71,12 +71,8 @@ Connection.prototype.callMethod = function(
   interfaceName, methodName, args, callback
 ) {
   var packet = this.createPacket('call', interfaceName, methodName, args);
-
-  if (callback) {
-    var packetId = packet.call[0];
-    this._callbacks[packetId] = callback;
-  }
-
+  var packetId = packet.call[0];
+  this._callbacks[packetId] = callback || common.doNothing;
   this._send(packet);
 };
 
@@ -131,20 +127,18 @@ Connection.prototype.notifyStateChange = function(path, verb, value) {
 //
 Connection.prototype.handshake = function(appName, login, password, callback) {
   var packet = this.createPacket('handshake', appName, login, password);
+  var packetId = packet.handshake[0];
+  var self = this;
 
-  if (callback) {
-    var packetId = packet.handshake[0];
-    var self = this;
-
-    this._callbacks[packetId] = function(error, sessionId) {
-      if (login && password && !error) {
-        self.username = login;
-      }
-
-      self.sessionId = sessionId;
+  this._callbacks[packetId] = function(error, sessionId) {
+    if (login && password && !error) {
+      self.username = login;
+    }
+    self.sessionId = sessionId;
+    if (callback) {
       callback(error, sessionId);
-    };
-  }
+    }
+  };
 
   this._send(packet);
 };
@@ -182,11 +176,7 @@ Connection.prototype.inspectInterface = function(interfaceName, callback) {
 Connection.prototype.ping = function(callback) {
   var packet = this.createPacket('ping');
   var packetId = packet.ping[0];
-  this._callbacks[packetId] = function() {
-    if (callback) {
-      callback();
-    }
-  };
+  this._callbacks[packetId] = callback || common.doNothing;
   this._send(packet);
 };
 


### PR DESCRIPTION
For some public methods of Connection that perform network actions
callbacks are optional. This commit fixes the behavior of default
actions when a callback function is not passed so that (1) the system
logic is always run and (2) a Connection doesn't complain about
callback packets for unknown source packets.

Backport-of: https://github.com/metarhia/JSTP/pull/52