### PR TITLE
(v0.5 backport) server: handle connection errors before handshake

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -98,6 +98,10 @@ Server.prototype._onRawConnection = function(socket) {
   var connection = new Connection(this.rawServer.createTransport(socket), this);
   var server = this;
 
+  connection.on('error', function(error) {
+    this.emit('connectionError', error, connection);
+  });
+
   connection.setTimeout(HANDSHAKE_TIMEOUT, function() {
     if (!connection.handshakeDone) {
       connection.close();
@@ -114,11 +118,6 @@ Server.prototype._onRawConnection = function(socket) {
 Server.prototype._onClientConnect = function(connection) {
   this.clients[connection.id] = connection;
   this._cachedClientsArray.push(connection);
-
-  var server = this;
-  connection.on('error', function(error) {
-    server.emit('connectionError', error, connection);
-  });
 };
 
 // Client connection close event handler


### PR DESCRIPTION
This commit fixes a critical issue that allowed to crash the server
with an unhandled error event sending an invalid packet that causes
parser error before a handshake.

Fixes: https://github.com/metarhia/JSTP/issues/76
Backport-of: https://github.com/metarhia/JSTP/pull/78