### PR TITLE
(v0.5 backport) w3c-ws: fix invalid property access

### DIFF
--- a/lib/transport.ws.browser.js
+++ b/lib/transport.ws.browser.js
@@ -83,11 +83,9 @@ W3CWebSocketClient.prototype.connect = function(callback) {
 //
 W3CWebSocketClient.prototype.disconnect = function(callback) {
   this._ensureConnected();
-
   if (callback) {
-    this.connection.once('close', callback);
+    this.socketEventEmitter.once('close', callback);
   }
-
   this.socket.close();
 };
 


### PR DESCRIPTION
s/connection/socketEventEmitter

Backport-of: https://github.com/metarhia/JSTP/pull/94