### PR TITLE
add arrow-parens rule to eslint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -136,6 +136,10 @@ rules:
   no-use-before-define:
     - error
     - functions: false
+  arrow-parens:
+    - error
+    - as-needed
+    - requireForBlockBody: true
   arrow-body-style:
     - error
     - as-needed

--- a/lib/client.js
+++ b/lib/client.js
@@ -114,7 +114,7 @@ Client.prototype.connectAndInspect = function(
       // this kind of things, but there are some issues that must be resolved
       // prior to using it here.
       Promise.all(
-        interfaces.map((name) => new Promise((resolve, reject) => {
+        interfaces.map(name => new Promise((resolve, reject) => {
           connection.inspectInterface(name, (error, proxy) => {
             if (error) {
               reject(error);

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -59,7 +59,7 @@ RemoteError.prototype.toJstpArray = function() {
 // Factory method that creates a RemoteError instance from a JSTP array
 //   array - array in the form of [code, description]
 //
-RemoteError.fromJstpArray = (array) => new RemoteError(array[0], array[1]);
+RemoteError.fromJstpArray = array => new RemoteError(array[0], array[1]);
 
 // Prepare an error to be sent in a JSTP packet
 //   error - an error to prepare (instance of Error, RemoteError, a string or

--- a/test/unit/serializer.test.js
+++ b/test/unit/serializer.test.js
@@ -186,7 +186,7 @@ function testSyntaxError(parseFunction) {
       '#+',
       '\'\\u{\'',
       '\'\\u{}\''
-    ].map((input) => jstp[parseFunction].bind(null, input)).forEach((fn) => {
+    ].map(input => jstp[parseFunction].bind(null, input)).forEach((fn) => {
       expect(fn).to.throw();
     });
   });
@@ -218,7 +218,7 @@ describe('JSTP Serializer and Deserializer', () => {
       it('must not allow functions', () => {
         [ '{key:42,fn:function(){}}',
           '{get value() { return 42; }, set value(val) {}}'
-        ].map((input) => jstp.parse.bind(null, input)).forEach((fn) => {
+        ].map(input => jstp.parse.bind(null, input)).forEach((fn) => {
           expect(fn).to.throw();
         });
       });

--- a/tools/common.js
+++ b/tools/common.js
@@ -15,7 +15,7 @@ common.getCommandOutput = (cmd) => {
   });
 };
 
-common.promisify = (fn) => (...args) => (
+common.promisify = fn => (...args) => (
   new Promise((resolve, reject) => {
     fn(...args, (error, ...result) => {
       if (error) reject(error);

--- a/tools/prepare-release.js
+++ b/tools/prepare-release.js
@@ -96,7 +96,7 @@ function getMetadata(commitHash) {
     const repo = prUrl && prUrl.repo;
     const pr = prUrl && prUrl.id;
 
-    return getSemverTag(repo, pr).then((tag) => ({
+    return getSemverTag(repo, pr).then(tag => ({
       hash: commitHash,
       author,
       message,


### PR DESCRIPTION
Force eslint to throw an error on arrow function with braces
but without parens, this will make code a bit more consistent