### PR TITLE
cli: implement autocompletion for cli commands

### DIFF
--- a/tools/cli.js
+++ b/tools/cli.js
@@ -189,7 +189,7 @@ function _split(str, separator, limit, leaveEmpty) {
   let start = 0;
 
   const shouldPush = end =>
-    start !== end || (leaveEmpty && !result[result.length - 1]);
+    start !== end || (leaveEmpty && result[result.length - 1] !== '');
 
   // eslint-disable-next-line no-unmodified-loop-condition
   while (!limit || result.length < limit) {

--- a/tools/cli.js
+++ b/tools/cli.js
@@ -110,7 +110,7 @@ const state = {
 };
 
 commandProcessor.complete = (inputs, depth) => {
-  const completions = ['call', 'event', 'connect', 'disconnect', 'exit'];
+  const completions = ['call', 'connect', 'disconnect', 'event', 'exit'];
   const cmd = inputs[depth];
   return [complete(cmd, completions), depth + 1];
 };
@@ -174,7 +174,7 @@ commandProcessor.exit = () => {
 // limit - resulting length of output array - 1 (last one is what's left),
 //         if !limit === true => means no limit and split till no more
 //         separators found
-// leaveEmpty - if true multiple separators in sequence will be added as empty
+// leaveEmpty - if true multiple separators in sequence will be added as
 //              empty string, else they are skipped
 //
 // returns an array of strings

--- a/tools/cli.js
+++ b/tools/cli.js
@@ -67,8 +67,12 @@ function iterativeCompletion(inputs, depth, completer) {
     }
     return [completions, help];
   }
-  const [newCompletions, newDepth] = completer._complete(inputs, depth);
-  return helper(newDepth, depth, completer, newCompletions);
+  if (completer._complete) {
+    const [newCompletions, newDepth] = completer._complete(inputs, depth);
+    return helper(newDepth, depth, completer, newCompletions);
+  }
+  if (completer._help) return [[], completer._help()];
+  return [[], ''];
 }
 
 rl.on('line', (line) => {

--- a/tools/cli.js
+++ b/tools/cli.js
@@ -101,24 +101,37 @@ commandProcessor.exit = () => {
   process.exit();
 };
 
+// str - inputs string
+// separator - string to use as a separator
+// limit - resulting length of output array - 1 (last one is what's left),
+//         if !limit === true => means no limit and split till no more
+//         separators found
+// leaveEmpty - if true multiple separators in sequence will be added as empty
+//              empty string, else they are skipped
+//
+// returns an array of strings
+//
+// the behaviour is as follows:
+//  splits 'str' till limit is bound or no more separators left in 'str'
+//  if leaveEmpty is true then multiple separators in sequence are written in
+//  resulting array as one empty string (''), else they are skipped
+//  and doesn't get counted to limit
 function _split(str, separator, limit, leaveEmpty) {
-  const shouldTrim = (start, split) => !leaveEmpty && start === split;
+  const isLastEmpty = arr => !arr[arr.length - 1];
 
   const result = [];
   let start = 0;
 
   // eslint-disable-next-line no-unmodified-loop-condition
-  for (let i = 0; !limit || i < limit; i++) {
+  while (!limit || limit - result.length > 0) {
     const split = str.indexOf(separator, start);
     if (split === -1) break;
-    if (!shouldTrim(start, split)) {
+    if (start !== split || leaveEmpty && !isLastEmpty(result)) {
       result.push(str.slice(start, split));
-    } else  {
-      i--;
     }
     start = split + separator.length;
   }
-  if (!shouldTrim(start, str.length)) {
+  if (start !== str.length || leaveEmpty && !isLastEmpty(result)) {
     result.push(str.slice(start));
   }
   return result;

--- a/tools/cli.js
+++ b/tools/cli.js
@@ -62,8 +62,8 @@ function iterativeCompletion(inputs, depth, completer) {
       return helper(newDepth, depth, nextCompleter, newCompletions);
     }
     if (inputs[oldDepth] === completions[0]) {
-      completions.shift();
       if (nextCompleter.help) help = nextCompleter.help();
+      return [[], help];
     }
     return [completions, help];
   }
@@ -185,23 +185,20 @@ commandProcessor.exit = () => {
 //  resulting array as one empty string (''), else they are skipped
 //  and doesn't get counted to limit
 function _split(str, separator, limit, leaveEmpty) {
-  const isLastEmpty = arr => !arr[arr.length - 1];
-
   const result = [];
   let start = 0;
 
+  const shouldPush = end =>
+    start !== end || (leaveEmpty && !result[result.length - 1]);
+
   // eslint-disable-next-line no-unmodified-loop-condition
-  while (!limit || limit - result.length > 0) {
+  while (!limit || result.length < limit) {
     const split = str.indexOf(separator, start);
     if (split === -1) break;
-    if (start !== split || leaveEmpty && !isLastEmpty(result)) {
-      result.push(str.slice(start, split));
-    }
+    if (shouldPush(split)) result.push(str.slice(start, split));
     start = split + separator.length;
   }
-  if (start !== str.length || leaveEmpty && !isLastEmpty(result)) {
-    result.push(str.slice(start));
-  }
+  if (shouldPush(str.length)) result.push(str.slice(start));
   return result;
 }
 


### PR DESCRIPTION
Implements 'Autocompletion for CLI commands' and allows to implement 'Autocompletion for method names' (#125)

The behavior is as follows:
* on empty string (or trailing space) just show what commands are available for current level
* on partially entered commands show appropriate completions
* on fully entered command with no trailing space or when no completions available show help
* allow to use partially entered command without completing them it there are no collisions