### PR TITLE
lint: add import/no-unresolved ESLint rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,6 +2,8 @@ env:
   node: true
   es6: true
 extends: 'eslint:recommended'
+plugins:
+  - import
 rules:
   indent:
     - error
@@ -173,3 +175,6 @@ rules:
   template-curly-spacing:
     - error
     - never
+  import/no-unresolved:
+    - error
+    - commonjs: true

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "chai": "^3.5.0",
     "chai-spies": "^0.7.1",
     "eslint": "^3.12.2",
+    "eslint-plugin-import": "^2.2.0",
     "karma": "^1.3.0",
     "karma-chrome-launcher": "^2.0.0",
     "karma-firefox-launcher": "^1.0.0",


### PR DESCRIPTION
I am planning to rearrange the structure of `lib` a little bit, so I decided to add this rule to be safe doing this. And it is a nice thing to have generally.