### PR TITLE
ws: fix emitting error when callback is provided

### DIFF
--- a/lib/transport.ws.js
+++ b/lib/transport.ws.js
@@ -195,7 +195,7 @@ JstpWebSocketClient.prototype.connect = function(callback) {
 
   this.wsClient.once('connectFailed', (error) => {
     if (callback) {
-      callback(error);
+      return callback(error);
     }
 
     this.emit('error', error);


### PR DESCRIPTION
Fix WebSocket client emitting error on connection when callback is
provided.