### PR TITLE
connection: fix error handling in optional cbs

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -77,7 +77,9 @@ Connection.prototype.callMethod = function(
 ) {
   const packet = this.createPacket('call', interfaceName, methodName, args);
   const packetId = packet.call[0];
-  this._callbacks[packetId] = callback || common.doNothing;
+  this._callbacks[packetId] = callback || ((error) => {
+    if (error) this.emit('error', error);
+  });
   this._send(packet);
 };
 
@@ -160,7 +162,12 @@ Connection.prototype.inspectInterface = function(interfaceName, callback) {
 
   this._callbacks[packetId] = (error, ...methods) => {
     if (error) {
-      return callback(error);
+      if (callback) {
+        callback(error);
+      } else {
+        this.emit('error', error);
+      }
+      return;
     }
 
     const proxy = new RemoteProxy(this, interfaceName, methods);


### PR DESCRIPTION
This commit makes error handling in methods that take optional
callbacks more robust.

* Fix a possible TypeError in `inspectInterface()`.
* Ensure that an error is not lost in `inspectInterface()` and
  `callMethod()` by emitting it on the connection if there's no
  callback.