### PR TITLE
npm: don't publish tests in the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -23,3 +23,6 @@ mkdocs.yml
 
 # Examples
 examples/
+
+# Tests
+test/


### PR DESCRIPTION
Given that https://github.com/metarhia/JSTP/pull/158 has introduced
quite a massive chunk of test fixtures, it is better to avoid including
tests with the npm package.  At this point it saves 632 KB of disk
space.