### PR TITLE
(v0.6 backport) connection: fix error handling in optional cbs

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -158,7 +158,10 @@ Connection.prototype.inspectInterface = function(interfaceName, callback) {
 
   this._callbacks[packetId] = (error, ...methods) => {
     if (error) {
-      return callback(error);
+      if (callback) {
+        callback(error);
+      }
+      return;
     }
 
     const proxy = new RemoteProxy(this, interfaceName, methods);


### PR DESCRIPTION
Original commit message:

>  This commit makes error handling in methods that take optional
>  callbacks more robust.
>
>  * Fix a possible TypeError in `inspectInterface()`.
>  * Ensure that an error is not lost in `inspectInterface()` and
>    `callMethod()` by emitting it on the connection if there's no
>    callback.

This backport follows a less aggressive approach and only fixes the
possible TypeError.  The 'error' events are not emitted in v0.6 because
it is a breaking change.

Backport-Of: e443548733692d110558ce85db5b99c8f002e605