### PR TITLE
doc: add notes for the 2017-04-11 meeting

### DIFF
--- a/doc/meetings/2017-04-11-core.md
+++ b/doc/meetings/2017-04-11-core.md
@@ -1,0 +1,77 @@
+# 2017-04-11 JSTP Core Maintainers Meeting
+
+**Invited:**
+
+* Alexey Orlenko &lt;eaglexrlnk@gmail.com&gt;
+  ([@aqrln](https://github.com/aqrln))
+* Denys Otrishko &lt;shishugi@gmail.com&gt;
+  ([@lundibundi](https://github.com/lundibundi))
+* Dmytro Nechai &lt;nechaido@gmail.com&gt;
+  ([@nechaido](https://github.com/nechaido))
+* Mykola Bilochub &lt;nbelochub@gmail.com&gt;
+  ([@belochub](https://github.com/belochub))
+* Timur Shemsedinov &lt;timur.shemsedinov@gmail.com&gt;
+  ([@tshemsedinov](https://github.com/tshemsedinov))
+
+**Present:**
+
+* Alexey Orlenko &lt;eaglexrlnk@gmail.com&gt;
+  ([@aqrln](https://github.com/aqrln))
+* Denys Otrishko &lt;shishugi@gmail.com&gt;
+  ([@lundibundi](https://github.com/lundibundi))
+* Dmytro Nechai &lt;nechaido@gmail.com&gt;
+  ([@nechaido](https://github.com/nechaido))
+* Mykola Bilochub &lt;nbelochub@gmail.com&gt;
+  ([@belochub](https://github.com/belochub))
+* Timur Shemsedinov &lt;timur.shemsedinov@gmail.com&gt;
+  ([@tshemsedinov](https://github.com/tshemsedinov))
+
+## Agenda
+
+1. Contribution guidelines.
+2. Relationship with <https://github.com/jstp>.
+3. Compliance with JSON5 specs. The future of our custom data formats.
+4. The front page of the project.
+
+## Decisions
+
+### 1. Contribution guidelines
+
+The number of active contributors has doubled over the last time, so the
+existing policy that allowed landing PRs as soon as they are approved does not
+work anymore. We have already encountered a situation when a PR has landed
+prematurely without a proper review from a collaborator other than one who had
+reviewed it and, consequently, without addressing their feedback. Because of
+that we need a minimal waiting time, which we have agreed upon to be 24 hours,
+skipping weekends and holidays.
+
+That, and all the conventions that we have had, must be documented.
+
+### 2. Relationship with <https://github.com/jstp>.
+
+Using the name "JSTP" when another similar project with the same name has
+already existed (even though it has been inactive for a long time) is
+inappropriate, may lead to confusion and is a potential infringement. We must
+get in touch with the people behind it and either get approval to use the name
+or rename our project.
+
+### 3. Compliance with JSON5 specs. The future of our custom data formats.
+
+What has been called "Record Serialization" should be plain JSON5. Given the
+fact that we have implemented some minor features not present in JSON5 specs
+(like ES2015 syntax for octal and binary literals), it is okay if we keep them,
+but the parser must be able to parse any valid JSON5 and the serializer must
+emit strict JSON5. In the future we might also consider decoupling the serdes
+facilities built into the JSTP into a separate npm package (like "fast-json5" or
+"metarhia-json5").
+
+What has been called "Object Serialization" should be removed from the codebase.
+There's no sensible use case for it and there's no way to implement it in secure
+and performant fashion.
+
+### 4. The front page of the project.
+
+The `README.md` file should be updated to reflect the current vision of the
+project. It is misleading in some points and makes people who try to get
+acquainted with the project confused. Besides that, a new section with the list
+of the project's maintainers should be added.


### PR DESCRIPTION
# 2017-04-11 JSTP Core Maintainers Meeting

**Invited:**

* Alexey Orlenko &lt;eaglexrlnk@gmail.com&gt; ([@aqrln](https://github.com/aqrln))
* Denys Otrishko &lt;shishugi@gmail.com&gt; ([@lundibundi](https://github.com/lundibundi))
* Dmytro Nechai &lt;nechaido@gmail.com&gt; ([@nechaido](https://github.com/nechaido))
* Mykola Bilochub &lt;nbelochub@gmail.com&gt; ([@belochub](https://github.com/belochub))
* Timur Shemsedinov &lt;timur.shemsedinov@gmail.com&gt; ([@tshemsedinov](https://github.com/tshemsedinov))

**Present:**

* Alexey Orlenko &lt;eaglexrlnk@gmail.com&gt; ([@aqrln](https://github.com/aqrln))
* Denys Otrishko &lt;shishugi@gmail.com&gt; ([@lundibundi](https://github.com/lundibundi))
* Dmytro Nechai &lt;nechaido@gmail.com&gt; ([@nechaido](https://github.com/nechaido))
* Mykola Bilochub &lt;nbelochub@gmail.com&gt; ([@belochub](https://github.com/belochub))
* Timur Shemsedinov &lt;timur.shemsedinov@gmail.com&gt; ([@tshemsedinov](https://github.com/tshemsedinov))

## Agenda

1. Contribution guidelines.
2. Relationship with <https://github.com/jstp>.
3. Compliance with JSON5 specs. The future of our custom data formats.
4. The front page of the project.

## Decisions

### 1. Contribution guidelines

The number of active contributors has doubled over the last time, so the existing policy that allowed landing PRs as soon as they are approved does not work anymore. We have already encountered a situation when a PR has landed prematurely without a proper review from a collaborator other than one who had reviewed it and, consequently, without addressing their feedback. Because of that we need a minimal waiting time, which we have agreed upon to be 24 hours, skipping weekends and holidays.

That, and all the conventions that we have had, must be documented.

### 2. Relationship with <https://github.com/jstp>.

Using the name "JSTP" when another similar project with the same name has already existed (even though it has been inactive for a long time) is inappropriate, may lead to confusion and is a potential infringement. We must get in touch with the people behind it and either get approval to use the name or rename our project.

### 3. Compliance with JSON5 specs. The future of our custom data formats.

What has been called "Record Serialization" should be plain JSON5. Given the fact that we have implemented some minor features not present in JSON5 specs (like ES2015 syntax for octal and binary literals), it is okay if we keep them, but the parser must be able to parse any valid JSON5 and the serializer must emit strict JSON5. In the future we might also consider decoupling the serdes facilities built into the JSTP into a separate npm package (like "fast-json5" or "metarhia-json5").

What has been called "Object Serialization" should be removed from the codebase.  There's no sensible use case for it and there's no way to implement it in secure and performant fashion.

### 4. The front page of the project.

The `README.md` file should be updated to reflect the current vision of the project. It is misleading in some points and makes people who try to get acquainted with the project confused. Besides that, a new section with the list of the project's maintainers should be added.