### PR TITLE
test: refactor tests 

### DIFF
--- a/test/node/message-parser.js
+++ b/test/node/message-parser.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const tap = require('tap');
+const test = require('tap').test;
 const jstp = require('../..');
 
 const testCases = require('../fixtures/message-parser');
@@ -8,8 +8,9 @@ const testCases = require('../fixtures/message-parser');
 testCases.forEach((testCase) => {
   const result = [];
   const remainder = jstp.parseNetworkPackets(testCase.message, result);
-  tap.strictSame(result, testCase.result,
-    `must properly parse ${testCase.name}`);
-  tap.strictSame(remainder, testCase.remainder,
-    `must leave a valid remainder after parsing ${testCase.name}`);
+  test(`must properly parse ${testCase.name}`, (test) => {
+    test.strictSame(result, testCase.result);
+    test.strictSame(remainder, testCase.remainder);
+    test.end();
+  });
 });

--- a/test/node/remote-error-constructor.js
+++ b/test/node/remote-error-constructor.js
@@ -1,14 +1,14 @@
 'use strict';
 
-const tap = require('tap');
+const test = require('tap').test;
 
-const jstp = require('../../');
+const jstp = require('../..');
 const RemoteError = jstp.RemoteError;
 
 const testCases = require('../fixtures/remote-error-test-cases');
 
 testCases.forEach((testCase) => {
-  tap.test(`Must properly construct an error with ${testCase.name}`, (test) => {
+  test(`Must properly construct an error with ${testCase.name}`, (test) => {
     const error = new RemoteError(testCase.code, testCase.message);
     test.type(error, Error, 'must be an error');
     test.type(error, RemoteError, 'must be a RemoteError');

--- a/test/node/remote-error-default-messages.js
+++ b/test/node/remote-error-default-messages.js
@@ -1,13 +1,15 @@
 'use strict';
 
-const tap = require('tap');
+const test = require('tap').test;
 
-const jstp = require('../../');
+const jstp = require('../..');
 const RemoteError = jstp.RemoteError;
 
 const expectedMessages = Object.keys(jstp)
   .filter(key => key.startsWith('ERR_'))
   .map(key => jstp[key].toString());
 
-tap.includes(Object.keys(RemoteError.defaultMessages), expectedMessages,
-  'Must have a default message for every predefined error');
+test('Must have a default message for every predefined error', (test) => {
+  test.includes(Object.keys(RemoteError.defaultMessages), expectedMessages);
+  test.end();
+});

--- a/test/node/remote-error-default-messages.js
+++ b/test/node/remote-error-default-messages.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const test = require('tap').test;
+const test = require('tap');
 
 const jstp = require('../..');
 const RemoteError = jstp.RemoteError;
@@ -9,7 +9,5 @@ const expectedMessages = Object.keys(jstp)
   .filter(key => key.startsWith('ERR_'))
   .map(key => jstp[key].toString());
 
-test('Must have a default message for every predefined error', (test) => {
-  test.includes(Object.keys(RemoteError.defaultMessages), expectedMessages);
-  test.end();
-});
+test.includes(Object.keys(RemoteError.defaultMessages), expectedMessages,
+  'Must have a default message for every predefined error');

--- a/test/node/remote-error-from-jstp-array.js
+++ b/test/node/remote-error-from-jstp-array.js
@@ -1,14 +1,14 @@
 'use strict';
 
-const tap = require('tap');
+const test = require('tap').test;
 
-const jstp = require('../../');
+const jstp = require('../..');
 const RemoteError = jstp.RemoteError;
 
 const testCases = require('../fixtures/remote-error-test-cases');
 
 testCases.forEach((testCase) => {
-  tap.test(`Must properly construct an error from array with ${testCase.name}`,
+  test(`Must properly construct an error from array with ${testCase.name}`,
     (test) => {
       const jstpArray = [testCase.code];
       if (testCase.message) {

--- a/test/node/remote-error-get-jstp-array.js
+++ b/test/node/remote-error-get-jstp-array.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const tap = require('tap');
+const test = require('tap').test;
 
-const jstp = require('../../');
+const jstp = require('../..');
 const RemoteError = jstp.RemoteError;
 
 const code = jstp.ERR_APP_NOT_FOUND;
@@ -45,6 +45,8 @@ const testCases = [
 
 testCases.forEach((testCase) => {
   const arr = RemoteError.getJstpArrayFor(testCase.value);
-  tap.strictSame(arr, testCase.expected,
-    `Must properly create an array from ${testCase.name}`);
+  test(`Must properly create an array from ${testCase.name}`, (test) => {
+    test.strictSame(arr, testCase.expected);
+    test.end();
+  });
 });

--- a/test/node/remote-error-to-jstp-array.js
+++ b/test/node/remote-error-to-jstp-array.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const tap = require('tap');
+const test = require('tap').test;
 
-const jstp = require('../../');
+const jstp = require('../..');
 const RemoteError = jstp.RemoteError;
 
 const testCases = require('../fixtures/remote-error-test-cases');
@@ -15,6 +15,9 @@ testCases.forEach((testCase) => {
     expextedJstpArray.push(testCase.expectedMessage);
   }
 
-  tap.strictSame(jstpArray, expextedJstpArray,
-    `Must properly construct jstp array from error with ${testCase.name}`);
+  test(`Must properly construct jstp array from error with ${testCase.name}`,
+    (test) => {
+      test.strictSame(jstpArray, expextedJstpArray);
+      test.end();
+    });
 });

--- a/test/node/serde.js
+++ b/test/node/serde.js
@@ -1,22 +1,28 @@
 'use strict';
 
-const tap = require('tap');
+const test = require('tap').test;
 
 const jstp = require('../..');
 
 const testCases = require('../fixtures/serde-test-cases');
 
 testCases.serde.concat(testCases.serialization).forEach((testCase) => {
-  tap.strictSame(jstp.stringify(testCase.value), testCase.serialized,
-    `must serialize ${testCase.name}`);
+  test(`must serialize ${testCase.name}`, (test) => {
+    test.strictSame(jstp.stringify(testCase.value), testCase.serialized);
+    test.end();
+  });
 });
 
 testCases.serde.concat(testCases.deserialization).forEach((testCase) => {
-  tap.strictSame(jstp.parse(testCase.serialized), testCase.value,
-    `must deserialize ${testCase.name}`);
+  test(`must deserialize ${testCase.name}`, (test) => {
+    test.strictSame(jstp.parse(testCase.serialized), testCase.value);
+    test.end();
+  });
 });
 
 testCases.invalidDeserialization.forEach((testCase) => {
-  tap.throws(() => jstp.parse(testCase.value),
-    `must not allow ${testCase.name}`);
+  test(`must not allow ${testCase.name}`, (test) => {
+    test.throws(() => jstp.parse(testCase.value));
+    test.end();
+  });
 });


### PR DESCRIPTION
Fixes: https://github.com/metarhia/jstp/issues/181

@belochub I'd like to ask you to run this test on your branch to see if output is ok.

Currently I get this output if there're some errors:
<details><summary> npm test</summary><p>

```
test/node/message-parser.js ........................... 8/8
test/node/serde.js .................................. 63/65
  must serialize sparse arrays
  not ok should be equivalent strictly
    +++ found                                                           
    --- wanted                                                          
    -[1,,3                                                              
    +[1,,3]                                                             
    at:
      line: 11
      column: 10
      file: test/node/serde.js
      type: Test
      function: test
    stack: |
      Test.test (test/node/serde.js:11:10)
      testCases.serde.concat.forEach (test/node/serde.js:10:3)
      Array.forEach (native)
      Object.<anonymous> (test/node/serde.js:9:49)
    source: |
      test.strictSame(jstp.stringify(testCase.value), testCase.serialized);
  
  must not allow illegal input #1
  not ok expected to throw
    at:
      line: 25
      column: 10
      file: test/node/serde.js
      type: Test
      function: test
    stack: |
      Test.test (test/node/serde.js:25:10)
      testCases.invalidDeserialization.forEach (test/node/serde.js:24:3)
      Array.forEach (native)
      Object.<anonymous> (test/node/serde.js:23:34)
    source: |
      test.throws(() => jstp.parse(testCase.value));

total ............................................... 71/73
  

  71 passing (668.263ms)
  2 failing
```

</p></details>

<details><summary> node test/node/serde.js</summary><p>

```
TAP version 13
# Subtest: must serialize true
    ok 1 - should be equivalent strictly
    1..1
ok 1 - must serialize true # time=5.256ms

# Subtest: must serialize false
    ok 1 - should be equivalent strictly
    1..1
ok 2 - must serialize false # time=0.809ms

# Subtest: must serialize integer
    ok 1 - should be equivalent strictly
    1..1
ok 3 - must serialize integer # time=0.99ms

# Subtest: must serialize negative integer
    ok 1 - should be equivalent strictly
    1..1
ok 4 - must serialize negative integer # time=0.547ms

# Subtest: must serialize float
    ok 1 - should be equivalent strictly
    1..1
ok 5 - must serialize float # time=0.983ms

# Subtest: must serialize float with comma
    ok 1 - should be equivalent strictly
    1..1
ok 6 - must serialize float with comma # time=0.332ms

# Subtest: must serialize small float
    ok 1 - should be equivalent strictly
    1..1
ok 7 - must serialize small float # time=0.481ms

# Subtest: must serialize undefined
    ok 1 - should be equivalent strictly
    1..1
ok 8 - must serialize undefined # time=0.376ms

# Subtest: must serialize null
    ok 1 - should be equivalent strictly
    1..1
ok 9 - must serialize null # time=1.515ms

# Subtest: must serialize string
    ok 1 - should be equivalent strictly
    1..1
ok 10 - must serialize string # time=0.618ms

# Subtest: must serialize string with endline
    ok 1 - should be equivalent strictly
    1..1
ok 11 - must serialize string with endline # time=0.922ms

# Subtest: must serialize string with single quote
    ok 1 - should be equivalent strictly
    1..1
ok 12 - must serialize string with single quote # time=0.704ms

# Subtest: must serialize string with Unicode escape sequences
    ok 1 - should be equivalent strictly
    1..1
ok 13 - must serialize string with Unicode escape sequences # time=0.605ms

# Subtest: must serialize empty array
    ok 1 - should be equivalent strictly
    1..1
ok 14 - must serialize empty array # time=0.566ms

# Subtest: must serialize array of integers
    ok 1 - should be equivalent strictly
    1..1
ok 15 - must serialize array of integers # time=0.344ms

# Subtest: must serialize nested arrays
    ok 1 - should be equivalent strictly
    1..1
ok 16 - must serialize nested arrays # time=0.339ms

# Subtest: must serialize empty object
    ok 1 - should be equivalent strictly
    1..1
ok 17 - must serialize empty object # time=2.871ms

# Subtest: must serialize object
    ok 1 - should be equivalent strictly
    1..1
ok 18 - must serialize object # time=0.471ms

# Subtest: must serialize Marcus array
    ok 1 - should be equivalent strictly
    1..1
ok 19 - must serialize Marcus array # time=0.306ms

# Subtest: must serialize Marcus object
    ok 1 - should be equivalent strictly
    1..1
ok 20 - must serialize Marcus object # time=0.309ms

# Subtest: must serialize sparse arrays
    not ok 1 - should be equivalent strictly
      ---
      found: '[1,,3]'
      wanted: '[1,,3'
      at:
        line: 11
        column: 10
        file: test/node/serde.js
        type: Test
        function: test
      stack: |
        Test.test (test/node/serde.js:11:10)
        testCases.serde.concat.forEach (test/node/serde.js:10:3)
        Array.forEach (native)
        Object.<anonymous> (test/node/serde.js:9:49)
      source: |
        test.strictSame(jstp.stringify(testCase.value), testCase.serialized);
      ...
    
    1..1
    # failed 1 test
not ok 21 - must serialize sparse arrays # time=17.066ms

# Subtest: must serialize object omitting undefined fields
    ok 1 - should be equivalent strictly
    1..1
ok 22 - must serialize object omitting undefined fields # time=0.36ms

# Subtest: must serialize object omitting functions
    ok 1 - should be equivalent strictly
    1..1
ok 23 - must serialize object omitting functions # time=1.573ms

# Subtest: must serialize object with non-identifier keys
    ok 1 - should be equivalent strictly
    1..1
ok 24 - must serialize object with non-identifier keys # time=0.345ms

# Subtest: must deserialize true
    ok 1 - should be equivalent strictly
    1..1
ok 25 - must deserialize true # time=0.45ms

# Subtest: must deserialize false
    ok 1 - should be equivalent strictly
    1..1
ok 26 - must deserialize false # time=0.317ms

# Subtest: must deserialize integer
    ok 1 - should be equivalent strictly
    1..1
ok 27 - must deserialize integer # time=0.582ms

# Subtest: must deserialize negative integer
    ok 1 - should be equivalent strictly
    1..1
ok 28 - must deserialize negative integer # time=0.311ms

# Subtest: must deserialize float
    ok 1 - should be equivalent strictly
    1..1
ok 29 - must deserialize float # time=0.492ms

# Subtest: must deserialize float with comma
    ok 1 - should be equivalent strictly
    1..1
ok 30 - must deserialize float with comma # time=1.265ms

# Subtest: must deserialize small float
    ok 1 - should be equivalent strictly
    1..1
ok 31 - must deserialize small float # time=0.461ms

# Subtest: must deserialize undefined
    ok 1 - should be equivalent strictly
    1..1
ok 32 - must deserialize undefined # time=0.428ms

# Subtest: must deserialize null
    ok 1 - should be equivalent strictly
    1..1
ok 33 - must deserialize null # time=0.376ms

# Subtest: must deserialize string
    ok 1 - should be equivalent strictly
    1..1
ok 34 - must deserialize string # time=0.308ms

# Subtest: must deserialize string with endline
    ok 1 - should be equivalent strictly
    1..1
ok 35 - must deserialize string with endline # time=0.287ms

# Subtest: must deserialize string with single quote
    ok 1 - should be equivalent strictly
    1..1
ok 36 - must deserialize string with single quote # time=0.248ms

# Subtest: must deserialize string with Unicode escape sequences
    ok 1 - should be equivalent strictly
    1..1
ok 37 - must deserialize string with Unicode escape sequences # time=0.429ms

# Subtest: must deserialize empty array
    ok 1 - should be equivalent strictly
    1..1
ok 38 - must deserialize empty array # time=0.455ms

# Subtest: must deserialize array of integers
    ok 1 - should be equivalent strictly
    1..1
ok 39 - must deserialize array of integers # time=0.637ms

# Subtest: must deserialize nested arrays
    ok 1 - should be equivalent strictly
    1..1
ok 40 - must deserialize nested arrays # time=0.386ms

# Subtest: must deserialize empty object
    ok 1 - should be equivalent strictly
    1..1
ok 41 - must deserialize empty object # time=0.58ms

# Subtest: must deserialize object
    ok 1 - should be equivalent strictly
    1..1
ok 42 - must deserialize object # time=0.532ms

# Subtest: must deserialize Marcus array
    ok 1 - should be equivalent strictly
    1..1
ok 43 - must deserialize Marcus array # time=0.34ms

# Subtest: must deserialize Marcus object
    ok 1 - should be equivalent strictly
    1..1
ok 44 - must deserialize Marcus object # time=1.41ms

# Subtest: must deserialize object with whitespaces
    ok 1 - should be equivalent strictly
    1..1
ok 45 - must deserialize object with whitespaces # time=1.843ms

# Subtest: must deserialize object with single-quoted keys
    ok 1 - should be equivalent strictly
    1..1
ok 46 - must deserialize object with single-quoted keys # time=0.284ms

# Subtest: must deserialize object with double-quoted keys
    ok 1 - should be equivalent strictly
    1..1
ok 47 - must deserialize object with double-quoted keys # time=0.285ms

# Subtest: must deserialize binary numbers
    ok 1 - should be equivalent strictly
    1..1
ok 48 - must deserialize binary numbers # time=0.232ms

# Subtest: must deserialize octal numbers
    ok 1 - should be equivalent strictly
    1..1
ok 49 - must deserialize octal numbers # time=0.25ms

# Subtest: must deserialize hexadecimal numbers
    ok 1 - should be equivalent strictly
    1..1
ok 50 - must deserialize hexadecimal numbers # time=0.28ms

# Subtest: must deserialize hexadecimal numbers in upper case
    ok 1 - should be equivalent strictly
    1..1
ok 51 - must deserialize hexadecimal numbers in upper case # time=0.27ms

# Subtest: must deserialize Unicode code point escapes
    ok 1 - should be equivalent strictly
    1..1
ok 52 - must deserialize Unicode code point escapes # time=0.331ms

# Subtest: must deserialize sparse array
    ok 1 - should be equivalent strictly
    1..1
ok 53 - must deserialize sparse array # time=0.304ms

# Subtest: must not allow illegal input #1
    not ok 1 - expected to throw
      ---
      at:
        line: 25
        column: 10
        file: test/node/serde.js
        type: Test
        function: test
      stack: |
        Test.test (test/node/serde.js:25:10)
        testCases.invalidDeserialization.forEach (test/node/serde.js:24:3)
        Array.forEach (native)
        Object.<anonymous> (test/node/serde.js:23:34)
      source: |
        test.throws(() => jstp.parse(testCase.value));
      ...
    
    1..1
    # failed 1 test
not ok 54 - must not allow illegal input #1 # time=3.128ms

# Subtest: must not allow illegal input #2
    ok 1 - expected to throw
    1..1
ok 55 - must not allow illegal input #2 # time=0.606ms

# Subtest: must not allow illegal input #3
    ok 1 - expected to throw
    1..1
ok 56 - must not allow illegal input #3 # time=0.279ms

# Subtest: must not allow illegal input #4
    ok 1 - expected to throw
    1..1
ok 57 - must not allow illegal input #4 # time=1.083ms

# Subtest: must not allow illegal input #5
    ok 1 - expected to throw
    1..1
ok 58 - must not allow illegal input #5 # time=0.595ms

# Subtest: must not allow illegal input $6
    ok 1 - expected to throw
    1..1
ok 59 - must not allow illegal input $6 # time=0.404ms

# Subtest: must not allow old octal literals
    ok 1 - expected to throw
    1..1
ok 60 - must not allow old octal literals # time=0.258ms

# Subtest: must not allow functions
    ok 1 - expected to throw
    1..1
ok 61 - must not allow functions # time=0.313ms

# Subtest: must not allow properties
    ok 1 - expected to throw
    1..1
ok 62 - must not allow properties # time=0.326ms

# Subtest: must not allow missing closing bracket in array
    ok 1 - expected to throw
    1..1
ok 63 - must not allow missing closing bracket in array # time=0.293ms

# Subtest: must not allow missing closing brace in object
    ok 1 - expected to throw
    1..1
ok 64 - must not allow missing closing brace in object # time=0.261ms

# Subtest: must not allow missing value in object
    ok 1 - expected to throw
    1..1
ok 65 - must not allow missing value in object # time=0.311ms

1..65
# failed 2 of 65 tests
# time=176.81ms

```

</p></details>
