### PR TITLE
lib: change event signature

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -106,7 +106,7 @@ Connection.prototype.callback = function(packetId, error, result) {
 // Send an event packet over the connection
 //   interfaceName - name of an interface
 //   eventName - name of an event
-//   args - event arguments as an object
+//   args - event arguments as an array
 //
 Connection.prototype.emitRemoteEvent = function(
   interfaceName, eventName, args
@@ -539,7 +539,7 @@ Connection.prototype._processEventPacket = function(packet, keys) {
 
   const remoteProxy = this.remoteProxies[interfaceName];
   if (remoteProxy) {
-    remoteProxy.emit(eventName, eventArgs, true);
+    remoteProxy._emitLocal(eventName, eventArgs);
   }
 };
 

--- a/lib/remote-proxy.js
+++ b/lib/remote-proxy.js
@@ -37,8 +37,7 @@ RemoteProxy.prototype.emit = function(eventName, ...eventArgs) {
 //   eventName - name of an event
 //   eventArgs - array of event arguments
 //
-RemoteProxy.prototype._emitLocal = function(eventName, eventArgs) {
-  if (!eventArgs) eventArgs = [];
+RemoteProxy.prototype._emitLocal = function(eventName, eventArgs = []) {
   events.EventEmitter.prototype.emit.call(this, eventName, ...eventArgs);
 };
 

--- a/lib/remote-proxy.js
+++ b/lib/remote-proxy.js
@@ -24,22 +24,22 @@ function RemoteProxy(connection, interfaceName, methods = []) {
 
 util.inherits(RemoteProxy, events.EventEmitter);
 
-// Emit an event. By default, when the dontRetranslate parameter is false or
-// undefined, the event is also emmited on the other part of the JSTP
-// connection so all the 'on' handlers will work on both sides regardless of
-// where event has been emitted. However, you can turn it off by setting
-// dontRetranslate to true.
+// Emit an event.
 //   eventName - name of an event
-//   eventArgs - object of event arguments
-//   dontRetranslate - turn off sending the corresponding event packet over the
-//                     JSTP connection
+//   eventArgs - event arguments
 //
-RemoteProxy.prototype.emit = function(eventName, eventArgs, dontRetranslate) {
-  if (!dontRetranslate) {
-    this._connection.emitRemoteEvent(this._interfaceName, eventName, eventArgs);
-  }
+RemoteProxy.prototype.emit = function(eventName, ...eventArgs) {
+  this._connection.emitRemoteEvent(this._interfaceName, eventName, eventArgs);
+  this._emitLocal(eventName, eventArgs);
+};
 
-  events.EventEmitter.prototype.emit.call(this, eventName, eventArgs);
+// Emit local event.
+//   eventName - name of an event
+//   eventArgs - array of event arguments
+//
+RemoteProxy.prototype._emitLocal = function(eventName, eventArgs) {
+  if (!eventArgs) eventArgs = [];
+  events.EventEmitter.prototype.emit.call(this, eventName, ...eventArgs);
 };
 
 // Create a method in a remote proxy that will call the corresponding remote

--- a/test/unit/connection.test.js
+++ b/test/unit/connection.test.js
@@ -533,7 +533,7 @@ describe('JSTP Connection', () => {
 
   describe('event', () => {
     testPacketSending('event', (connection, transport) => {
-      const eventArgs = { arg: 'value' };
+      const eventArgs = [ 'value' ];
 
       const sendSpy = chai.spy((data) => {
         const packet = jstp.parse(data);

--- a/test/unit/remote-proxy.test.js
+++ b/test/unit/remote-proxy.test.js
@@ -20,7 +20,7 @@ describe('RemoteProxy', () => {
     emitRemoteEvent() { },
 
     processEventPacket() {
-      proxy.emit('testEvent', 'payload', true);
+      proxy._emitLocal('testEvent', ['payload1', 'payload2']);
     }
   };
 
@@ -64,14 +64,14 @@ describe('RemoteProxy', () => {
   it('must emit events through the network and locally', () => {
     const handler = chai.spy();
     proxy.on('testEvent', handler);
-    proxy.emit('testEvent', 'payload');
+    proxy.emit('testEvent', 'payload1', 'payload2');
 
     expect(eventSpy).to.have.been.called.exactly(1);
     expect(eventSpy).to.have.been.called.with(
-      'testInterface', 'testEvent', 'payload');
+      'testInterface', 'testEvent', ['payload1', 'payload2']);
 
     expect(handler).to.have.been.called.exactly(1);
-    expect(handler).to.have.been.called.with('payload');
+    expect(handler).to.have.been.called.with('payload1', 'payload2');
   });
 
   it('must not re-emit events back', () => {
@@ -79,7 +79,7 @@ describe('RemoteProxy', () => {
     proxy.on('testEvent', handler);
     connectionMock.processEventPacket();
 
-    expect(handler).to.have.been.called.with('payload');
+    expect(handler).to.have.been.called.with('payload1', 'payload2');
     expect(eventSpy).to.not.have.been.called();
   });
 });


### PR DESCRIPTION
Changes event message signature to always send an array
of arbitrary arguments. This makes it work same way as
EventEmitter does and also makes its usage similar to
call action.

Also the tests are just plainly awesome, but we will rewrite them soon anyway.