### PR TITLE
lib: add address method to Server

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -77,6 +77,11 @@ Server.prototype.close = function() {
   this._cachedClientsArray = [];
 };
 
+// Returns address this server is bound to
+Server.prototype.address = function() {
+  return this.rawServer.address();
+};
+
 // Get all clients as an array of JSTP connection instances
 //
 Server.prototype.getClients = function() {

--- a/lib/transport.socket.js
+++ b/lib/transport.socket.js
@@ -96,6 +96,11 @@ SocketServer.prototype.createTransport = function(socket) {
   return new SocketTransport(socket);
 };
 
+// Returns address this server is bound to
+SocketServer.prototype.address = function() {
+  return this.server.address();
+};
+
 // Socket connection client
 //   config - socket config
 //

--- a/lib/transport.ws.js
+++ b/lib/transport.ws.js
@@ -131,6 +131,11 @@ JstpWebSocketServer.prototype.createTransport = function(connection) {
   return new WebSocketTransport(connection);
 };
 
+// Returns address this server is bound to
+JstpWebSocketServer.prototype.address = function() {
+  return this.httpServer.address();
+};
+
 // WebSocket request handler
 //   request - WebSocket request
 //

--- a/test/node/get-server-address-ipc.js
+++ b/test/node/get-server-address-ipc.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const test = require('tap');
+const fs = require('fs');
+
+const jstp = require('../..');
+
+const app = new jstp.Application('name', {});
+
+const path = process.platform === 'win32' ?
+  '\\\\.\\pipe\\my-service' :
+  '/tmp/my-service.sock';
+const config = { path };
+
+const server = jstp.ipc.createServer(config, [app]);
+
+let triedToUnlink = false;
+
+server.on('close', () => {
+  fs.unlink(config.path, () => {
+    triedToUnlink = true;
+  });
+});
+
+process.on('exit', () => {
+  if (!triedToUnlink) {
+    fs.unlinkSync(config.path);
+  }
+});
+
+test.assertNot(server.address(),
+  'must return null address if server is not listening');
+
+server.listen(() => {
+  test.strictEqual(server.address(), config.path,
+    'must return correct port address upon listening');
+  server.close();
+});
+

--- a/test/node/get-server-address-tcp.js
+++ b/test/node/get-server-address-tcp.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const test = require('tap');
+
+const jstp = require('../..');
+
+const app = new jstp.Application('name', {});
+
+const server = jstp.tcp.createServer(0, [app]);
+
+test.assertNot(server.address(),
+  'must return null address if server is not listening');
+
+server.listen(() => {
+  const port = server.address().port;
+  test.ok(port > 0 && port < 65536,
+    'must return correct port number upon listening');
+  server.close();
+});

--- a/test/node/get-server-address-ws.js
+++ b/test/node/get-server-address-ws.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const test = require('tap');
+
+const jstp = require('../..');
+
+const app = new jstp.Application('name', {});
+
+const server = jstp.ws.createServer(0, [app]);
+
+test.assertNot(server.address(),
+  'must return null address if server is not listening');
+
+server.listen(() => {
+  const port = server.address().port;
+  test.ok(port > 0 && port < 65536,
+    'must return correct port number upon listening');
+  server.close();
+});


### PR DESCRIPTION
This allows to properly get server address parameters
without the need to break abstraction to get them from
low level server.