### PR TITLE
doc: update links to repos

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ JavaScript Transfer Protocol ("JSTP") is licensed for use as follows:
 MIT License
 
 Copyright (c) 2016–2017 JSTP contributors
-(see https://github.com/metarhia/JSTP/blob/master/AUTHORS).
+(see https://github.com/metarhia/jstp/blob/master/AUTHORS).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -26,7 +26,7 @@ SOFTWARE.
 """
 
 This license applies to parts of JSTP originating from the
-https://github.com/metarhia/Impress repository:
+https://github.com/metarhia/impress repository:
 
 """
 MIT License

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <br />
   <a href="https://travis-ci.org/metarhia/jstp">
     <img
-      src="https://travis-ci.org/metarhia/JSTP.svg?branch=master"
+      src="https://travis-ci.org/metarhia/jstp.svg?branch=master"
       alt="Travis CI"
     />
   </a>

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,8 +1,8 @@
 # JSTP / JavaScript Transfer Protocol
 
-[![Travis CI](https://travis-ci.org/metarhia/JSTP.svg?branch=master)](https://travis-ci.org/metarhia/JSTP)
-[![bitHound Dependencies](https://www.bithound.io/github/metarhia/JSTP/badges/dependencies.svg)](https://www.bithound.io/github/metarhia/JSTP/master/dependencies/npm)
-[![bitHound Score](https://www.bithound.io/github/metarhia/JSTP/badges/score.svg)](https://www.bithound.io/github/metarhia/JSTP)
+[![Travis CI](https://travis-ci.org/metarhia/jstp.svg?branch=master)](https://travis-ci.org/metarhia/jstp)
+[![bitHound Dependencies](https://www.bithound.io/github/metarhia/jstp/badges/dependencies.svg)](https://www.bithound.io/github/metarhia/jstp/master/dependencies/npm)
+[![bitHound Score](https://www.bithound.io/github/metarhia/jstp/badges/score.svg)](https://www.bithound.io/github/metarhia/jstp)
 [![NPM Version](https://badge.fury.io/js/metarhia-jstp.svg)](https://badge.fury.io/js/metarhia-jstp)
 [![NPM Downloads/Month](https://img.shields.io/npm/dm/metarhia-jstp.svg)](https://www.npmjs.com/package/metarhia-jstp)
 [![NPM Downloads](https://img.shields.io/npm/dt/metarhia-jstp.svg)](https://www.npmjs.com/package/metarhia-jstp)
@@ -25,8 +25,8 @@ in your code.
 
 Or, alternatively, if you are developing a client-side application for browser
 environment and don't use a module bundler like Webpack, you can grab
-[jstp.min.js](https://metarhia.github.io/JSTP/dist/jstp.min.js) and
-[jstp.min.js.map](https://metarhia.github.io/JSTP/dist/jstp.min.js.map).
+[jstp.min.js](https://metarhia.github.io/jstp/dist/jstp.min.js) and
+[jstp.min.js.map](https://metarhia.github.io/jstp/dist/jstp.min.js.map).
 JSTP will be available globally as `api.jstp`.
 
 ## Concept
@@ -92,7 +92,7 @@ processing that are based on some simple assumptions:
 
 | Implementation | Parser | TCP Client | TCP Server | WebSocket Client | WebSocket Server |
 | --- | :---: | :---: | :---: | :---: | :---: |
-| JavaScript<br>[metarhia/JSTP](https://github.com/metarhia/JSTP) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| JavaScript<br>[metarhia/jstp](https://github.com/metarhia/jstp) | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Swift<br>[JSTPMobile/iOS](https://github.com/JSTPMobile/iOS) | ✓ | ✓ | ✗ | ✗ | ✗ |
 | Java<br>[JSTPMobile/Java](https://github.com/JSTPMobile/Java) | ✓ | ✓ | ✗ | ✗ | ✗ |
 | Haskell<br>[DzyubSpirit/JSTPHaskell](https://github.com/DzyubSpirit/JSTPHaskell) | ✓ | ✓ | ✓ | ✗ | ✗ |

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -161,7 +161,7 @@ S: {handshake:[0],ok:'f3785d96d46a...def46f73'}
 It may be necessary for registration or public service. Server responds
 with a session ID.
 
-Successful handshake of [Impress](https://github.com/metarhia/Impress) worker
+Successful handshake of [Impress](https://github.com/metarhia/impress) worker
 connecting to a private cloud controller:
 
 ```javascript

--- a/lib/client.js
+++ b/lib/client.js
@@ -110,7 +110,7 @@ Client.prototype.connectAndInspect = function(
         return callback(error);
       }
 
-      // DataCollector from metarhia/MetaSync is a better abstraction to do
+      // DataCollector from metarhia/metasync is a better abstraction to do
       // this kind of things, but there are some issues that must be resolved
       // prior to using it here.
       Promise.all(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: JSTP
-site_url: https://metarhia.github.io/JSTP/
-repo_url: https://github.com/metarhia/JSTP/
+site_url: https://metarhia.github.io/jstp/
+repo_url: https://github.com/metarhia/jstp/
 edit_uri: edit/master/doc/
 docs_dir: doc
 pages:

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/metarhia/JSTP"
+    "url": "https://github.com/metarhia/jstp"
   },
   "bugs": {
-    "url": "https://github.com/metarhia/JSTP/issues",
+    "url": "https://github.com/metarhia/jstp/issues",
     "email": "timur.shemsedinov@gmail.com"
   },
   "main": "./jstp.js",


### PR DESCRIPTION
Update the rest of links to jstp, metasync, impress repos that became
obsolete after the repo renamed.