### PR TITLE
parser: disallow empty hex, octal, binary literals

### DIFF
--- a/src/jsrs_parser.cc
+++ b/src/jsrs_parser.cc
@@ -334,6 +334,10 @@ MaybeLocal<Value> ParseNumber(Isolate*    isolate,
   } else {
     result = ParseIntegerNumber(isolate, number_start, end, size,
                                 base, negate_result);
+    if (*size == 0) {
+      THROW_EXCEPTION(SyntaxError, "Empty number value");
+      return MaybeLocal<Value>();
+    }
   }
   *size += number_start - begin;
   return result;


### PR DESCRIPTION
Refs: https://github.com/metarhia/jstp/issues/175