### PR TITLE
parser: parse Unicode escape sequences in keys

### DIFF
--- a/test/fixtures/serde-test-cases/deserialization/string.js
+++ b/test/fixtures/serde-test-cases/deserialization/string.js
@@ -5,5 +5,10 @@ module.exports = [
     name: 'Unicode code point escapes',
     value: '💚💛',
     serialized: '\'\\u{1F49A}\\u{1F49B}\''
+  },
+  {
+    name: 'hexadecimal escape sequences',
+    value: 'Hello',
+    serialized: '\'\\x48\\x65\\x6c\\x6c\\x6f\''
   }
 ];

--- a/test/fixtures/serde-test-cases/invalid/index.js
+++ b/test/fixtures/serde-test-cases/invalid/index.js
@@ -48,5 +48,9 @@ module.exports = [
   {
     name: 'missing value in object',
     value: '{key:,}'
+  },
+  {
+    name: 'overflow in Unicode escape sequence',
+    value: '\'\\u{420420}\''
   }
 ];

--- a/test/fixtures/serde-test-cases/serde/string.js
+++ b/test/fixtures/serde-test-cases/serde/string.js
@@ -20,5 +20,10 @@ module.exports = [
     name: 'string with Unicode escape sequences',
     value: '01\u0000\u0001',
     serialized: '\'01\\u0000\\u0001\''
+  },
+  {
+    name: 'string with Unicode escape sequences followed by numbers',
+    value: '\u00000\u00011',
+    serialized: '\'\\u00000\\u00011\''
   }
 ];


### PR DESCRIPTION
Also, add support for Unicode surrogate pairs and improve key parsing performance by avoiding copying when possible.
Refs: https://github.com/metarhia/jstp/issues/152
