### PR TITLE
lib: support different loggers

### DIFF
--- a/jstp.js
+++ b/jstp.js
@@ -21,5 +21,11 @@ jstp.wss = require('./lib/wss');
 jstp.SimpleAuthPolicy = require('./lib/simple-auth-policy');
 jstp.SimpleConnectPolicy = require('./lib/simple-connect-policy');
 
-jstp.consoleLogger = require('./lib/console-logger');
-jstp.setLogger = require('./lib/logger').set;
+const logger = require('./lib/logger');
+jstp.log = {
+  consoleLogger: require('./lib/console-logger'),
+  set: logger.set,
+  winstonLevelCallback: logger.winstonLevelCallback,
+  bunyanLevelCallback: logger.bunyanLevelCallback,
+  defaultLevelCallback: logger.defaultLevelCallback
+};

--- a/jstp.js
+++ b/jstp.js
@@ -21,4 +21,5 @@ jstp.wss = require('./lib/wss');
 jstp.SimpleAuthPolicy = require('./lib/simple-auth-policy');
 jstp.SimpleConnectPolicy = require('./lib/simple-connect-policy');
 
+jstp.consoleLogger = require('./lib/console-logger');
 jstp.setLogger = require('./lib/logger').set;

--- a/jstp.js
+++ b/jstp.js
@@ -20,3 +20,5 @@ jstp.wss = require('./lib/wss');
 
 jstp.SimpleAuthPolicy = require('./lib/simple-auth-policy');
 jstp.SimpleConnectPolicy = require('./lib/simple-connect-policy');
+
+jstp.setLogger = require('./lib/logger').set;

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const logger = require('./logger');
+
 const common = {};
 module.exports = common;
 
@@ -33,7 +35,7 @@ common.safeRequire = (moduleName) => {
   try {
     return require(moduleName);
   } catch (err) {
-    console.warn(err.toString());
+    if (logger.isWarn()) logger.get().warn(err.toString());
     return null;
   }
 };

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -7,6 +7,7 @@ const common = require('./common');
 const jsrs = require('./record-serialization');
 const errors = require('./errors');
 const RemoteProxy = require('./remote-proxy');
+const logger = require('./logger');
 
 let nextConnectionId = 0;
 
@@ -272,6 +273,8 @@ class Connection extends EventEmitter {
   _send(packet) {
     const data = jsrs.stringify(packet);
     this.transport.send(data);
+
+    if (logger.isDebug()) logPacket(packet, data);
   }
 
   // Close the connection, optionally sending a final packet
@@ -283,6 +286,8 @@ class Connection extends EventEmitter {
     if (packet) {
       const data = jsrs.stringify(packet);
       this.transport.end(data);
+
+      if (logger.isDebug()) logPacket(packet, data);
     } else {
       this.transport.end();
     }
@@ -320,6 +325,8 @@ class Connection extends EventEmitter {
       this._rejectPacket(packet, true);
       return;
     }
+
+    if (logger.isDebug()) logPacket(packet);
 
     const handler = PACKET_HANDLERS[kind];
     if (handler) {
@@ -552,6 +559,16 @@ class Connection extends EventEmitter {
 }
 
 module.exports = Connection;
+
+function logPacket(packet, stringified) {
+  if (packet.handshake && !packet.ok && !packet.error && !packet.session) {
+    // remove private data
+    packet = { handshake: packet.handshake, login: 'password' };
+    stringified = null;
+  }
+  if (!stringified) stringified = jsrs.stringify(packet);
+  logger.get().debug(stringified);
+}
 
 PACKET_HANDLERS = {
   handshake: Connection.prototype._processHandshakePacket,

--- a/lib/console-logger.js
+++ b/lib/console-logger.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const consoleLogger = {};
+
+const logMapping = [
+  ['debug', 'log'], ['verbose', 'log'], 'info', 'warn', 'error'
+];
+logMapping.forEach((mapping) => {
+  let from, to;
+  if (Array.isArray(mapping)) {
+    [from, to] = mapping;
+  } else {
+    from = to = mapping;
+  }
+  consoleLogger[from] = (...args) => console[to](...args);
+});
+
+module.exports = consoleLogger;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -2,18 +2,60 @@
 
 let logger = null;
 
-const set = l => logger = l;
+const defaultLevelCallback = level => logger && logger[level];
+let isLevel = defaultLevelCallback;
+
+const levelToNumber = {
+  fatal: 60, error: 50,
+  warn: 40, info: 30,
+  verbose: 25, debug: 20,
+  silly: 10, trace: 10
+};
+
+const winstonLevelCallback =
+  level => levelToNumber[logger.level] <= levelToNumber[level];
+
+const bunyanLevelCallback =
+  level => logger.level() <= levelToNumber[level];
+
+// Set logger that will be used to forward JSTP logging
+//   loggerInstance - instance of logger that may have methods
+//                    'debug', 'verbose', 'info', 'warn', 'error', 'silly'.
+//                    It must have levels that levelCallback
+//                    reports as existing.
+//   levelCallback - function to check current logging level, will be
+//                   called with one of the:
+//                   'debug', 'verbose', 'info', 'warn', 'error', 'silly'.
+//                   by default defaultLevelCallback will be used that only
+//                   checks that such method exists.
+//                   You can provide your own or use one of the available:
+//                   winston (winstonLevelCallback) or
+//                   bunyan(bunyanLevelCallback).
+//                   In case of bunyan to support silly logging level
+//                   you must map 'silly' function to 'trace'.
+//
+const set = (loggerInstance, levelCallback) => {
+  if (loggerInstance) logger = loggerInstance;
+  if (levelCallback) isLevel = levelCallback;
+};
+
 const get = () => logger;
 
-const isDebug = () => logger && logger.debug;
-const isVerbose = () => logger && logger.verbose;
-const isInfo = () => logger && logger.info;
-const isWarn = () => logger && logger.warn;
-const isError = () => logger && logger.error;
+const isSilly = () => isLevel('silly');
+const isDebug = () => isLevel('debug');
+const isVerbose = () => isLevel('verbose');
+const isInfo = () => isLevel('info');
+const isWarn = () => isLevel('warn');
+const isError = () => isLevel('error');
 
 module.exports = {
-  set,
   get,
+  set,
+  winstonLevelCallback,
+  bunyanLevelCallback,
+  defaultLevelCallback,
+  isLevel,
+  isSilly,
   isDebug,
   isVerbose,
   isInfo,

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,22 @@
+'use strict';
+
+let logger = null;
+
+const set = l => logger = l;
+const get = () => logger;
+
+const isDebug = () => logger && logger.debug;
+const isVerbose = () => logger && logger.verbose;
+const isInfo = () => logger && logger.info;
+const isWarn = () => logger && logger.warn;
+const isError = () => logger && logger.error;
+
+module.exports = {
+  set,
+  get,
+  isDebug,
+  isVerbose,
+  isInfo,
+  isWarn,
+  isError
+};

--- a/lib/record-serialization.js
+++ b/lib/record-serialization.js
@@ -2,6 +2,7 @@
 
 const safeRequire = require('./common').safeRequire;
 const serialize = require('./json5-serialize');
+const logger = require('./logger');
 
 const jsrs = {};
 module.exports = jsrs;
@@ -22,10 +23,12 @@ if (jstpNative) {
     jsrs.stringify = serialize;
   }
 } else {
-  console.warn(
-    'JSTP native addon is not built or is not functional. ' +
-    'Run `npm install` in order to build it, otherwise you will get ' +
-    'poor performance.'
-  );
+  if (logger.isWarn()) {
+    logger.get().warn(
+      'JSTP native addon is not built or is not functional. ' +
+      'Run `npm install` in order to build it, otherwise you will get ' +
+      'poor performance.'
+    );
+  }
   module.exports = require('./record-serialization-fallback');
 }


### PR DESCRIPTION
Enables users to specify logger they want to use with our library. Also adds simple proxy to `console`.

As discussed in https://github.com/metarhia/jstp/issues/102 I extract logger fuctionality to a different PR.

Also I'd like to add a few tests for console logger, but I don't know how to better implement it, as I don't think that either redirecting console output during the test or just checking stdout is a good solution, can someone suggest a solution?