### PR TITLE
parser: deprecate legacy octal integer literals

### DIFF
--- a/src/jsrs_parser.cc
+++ b/src/jsrs_parser.cc
@@ -301,8 +301,6 @@ MaybeLocal<Value> ParseNumber(Isolate*    isolate,
   bool negate_result = false;
   const char* number_start = begin;
 
-  MaybeLocal<Value> result;
-
   if (*begin == '+' || *begin == '-') {
     negate_result = *begin == '-';
     number_start++;
@@ -330,6 +328,8 @@ MaybeLocal<Value> ParseNumber(Isolate*    isolate,
       number_start--;
     }
   }
+
+  MaybeLocal<Value> result;
 
   if (base == 10) {
     result = ParseDecimalNumber(isolate, number_start, end, size,

--- a/src/jsrs_parser.cc
+++ b/src/jsrs_parser.cc
@@ -299,7 +299,6 @@ MaybeLocal<Value> ParseNumber(Isolate*    isolate,
                               const char* end,
                               size_t*     size) {
   bool negate_result = false;
-  bool is_noctal = false;
   const char* number_start = begin;
 
   MaybeLocal<Value> result;
@@ -324,25 +323,23 @@ MaybeLocal<Value> ParseNumber(Isolate*    isolate,
       base = 16;
       number_start++;
     } else if (isdigit(*number_start)) {
-      is_noctal = true;
-      result = ParseNoctalNumber(isolate, number_start, end, size,
-                                 negate_result);
+      THROW_EXCEPTION(SyntaxError,
+          "Legacy octal and non-octal integer literals are not supported");
+      return MaybeLocal<Value>();
     } else {
       number_start--;
     }
   }
 
-  if (!is_noctal) {
-    if (base == 10) {
-      result = ParseDecimalNumber(isolate, number_start, end, size,
-                                  negate_result);
-    } else {
-      result = ParseIntegerNumber(isolate, number_start, end, size,
-                                  base, negate_result);
-      if (*size == 0) {
-        THROW_EXCEPTION(SyntaxError, "Empty number value");
-        return MaybeLocal<Value>();
-      }
+  if (base == 10) {
+    result = ParseDecimalNumber(isolate, number_start, end, size,
+                                negate_result);
+  } else {
+    result = ParseIntegerNumber(isolate, number_start, end, size,
+                                base, negate_result);
+    if (*size == 0) {
+      THROW_EXCEPTION(SyntaxError, "Empty number value");
+      return MaybeLocal<Value>();
     }
   }
   *size += number_start - begin;
@@ -427,55 +424,6 @@ Local<Value> ParseBigIntegerNumber(Isolate*    isolate,
     result += current_digit_value;
   }
   return Number::New(isolate, negate_result ? -result : result);
-}
-
-MaybeLocal<Value> ParseNoctalNumber(Isolate*    isolate,
-                                    const char* begin,
-                                    const char* end,
-                                    size_t*     size,
-                                    bool        negate_result) {
-  *size = end - begin;
-  bool is_octal = true;
-  int64_t result = 0;
-  bool int32_overflow = false;
-  double overflow_result = 0.0;
-  char current_digit;
-
-  for (size_t i = 0; i < *size; i++) {
-    if (!isdigit(begin[i])) {
-      *size = i;
-      break;
-    }
-
-    current_digit = begin[i] - '0';
-    if (current_digit > 7) {
-      is_octal = false;
-    }
-
-    if (!int32_overflow) {
-      result *= 10;
-      result += current_digit;
-    } else {
-      overflow_result *= 10.0;
-      overflow_result += current_digit;
-    }
-
-    if (!int32_overflow && (result < INT32_MIN || INT32_MAX < result)) {
-      int32_overflow = true;
-      overflow_result = result;
-    }
-  }
-
-  if (is_octal) {
-    THROW_EXCEPTION(SyntaxError, "Use new octal literal syntax");
-    return MaybeLocal<Value>();
-  }
-
-  if (!int32_overflow) {
-    return Integer::New(isolate, negate_result ? -result : result);
-  } else {
-    return Number::New(isolate, negate_result ? -overflow_result : overflow_result);
-  }
 }
 
 static bool GetControlChar(Isolate*    isolate,
@@ -669,7 +617,22 @@ static bool GetControlChar(Isolate*    isolate,
       break;
     }
 
+    case '0': {
+      if (isdigit(str[1])) {
+        THROW_EXCEPTION(SyntaxError,
+            "Decimal digits after \\0 are not allowed in strings");
+        return false;
+      }
+      *write_to = 0;
+      break;
+    }
+
     default: {
+      if ('0' <= str[0] && str[0] <= '7') {
+        THROW_EXCEPTION(SyntaxError,
+            "Octal escape sequences are not allowed in strings");
+        return false;
+      }
       *write_to = str[0];
     }
   }

--- a/src/jsrs_parser.h
+++ b/src/jsrs_parser.h
@@ -127,14 +127,6 @@ v8::Local<v8::Value> ParseBigIntegerNumber(v8::Isolate* isolate,
                                            int          base,
                                            bool         negate_result);
 
-// Parses a noctal integer number.
-v8::MaybeLocal<v8::Value> ParseNoctalNumber(v8::Isolate* isolate,
-                                            const char*  begin,
-                                            const char*  end,
-                                            std::size_t* size,
-                                            bool         negate_result);
-
-
 }  // namespace internal
 
 }  // namespace parser

--- a/test/todo/json5.js
+++ b/test/todo/json5.js
@@ -9,12 +9,6 @@ const supportedByUs = {
   arrays: [
     'leading-comma-array',
     'lone-trailing-comma-array'
-  ],
-  numbers: [
-    'negative-noctal',
-    'noctal-with-leading-octal-digit',
-    'noctal',
-    'positive-noctal'
   ]
 };
 


### PR DESCRIPTION
Also, deprecate legacy octal escape sequences in strings.

Refs: https://github.com/metarhia/jstp/issues/152