### PR TITLE
lib,parser: optimize parser and socket transport

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -62,25 +62,34 @@ class Transport extends EventEmitter {
   _onSocketData(chunk) {
     const messages = [];
     let parsedLength;
+    let newPartLength;
 
     if (this._buffer) {
-      this._buffer = Buffer.concat([this._buffer, chunk],
-        this._buffer.length + chunk.length);
-    } else {
-      this._buffer = chunk;
+      newPartLength = chunk.indexOf(0);
+      if (newPartLength === -1) {
+        this._buffer = Buffer.concat(
+          [this._buffer, chunk],
+          this._buffer.length + chunk.length
+        );
+        this._checkBufferSize();
+        return;
+      }
+      if (!this._parseRemains(chunk.slice(0, newPartLength), newPartLength)) {
+        return;
+      }
+      chunk = chunk.slice(newPartLength + 1);
+      this._buffer = null;
     }
 
     try {
-      parsedLength = serde.parseNetworkMessages(this._buffer, messages);
+      parsedLength = serde.parseNetworkMessages(chunk, messages);
     } catch (error) {
       this.socket.destroy(error);
       return;
     }
 
-    if (this._buffer.length === parsedLength) {
-      this._buffer = null;
-    } else {
-      this._buffer = this._buffer.slice(parsedLength);
+    if (chunk.length !== parsedLength) {
+      this._buffer = chunk.slice(parsedLength);
     }
 
     const messagesCount = messages.length;
@@ -88,7 +97,29 @@ class Transport extends EventEmitter {
       this.emit('message', messages[i]);
     }
 
-    if (this._buffer && this._buffer.length > MAX_MESSAGE_SIZE) {
+    if (this._buffer) {
+      this._checkBufferSize();
+    }
+  }
+
+  _parseRemains(newPart, newPartLength) {
+    let result;
+    const buffer = Buffer.concat(
+      [this._buffer, newPart],
+      this._buffer.length + newPartLength
+    );
+    try {
+      result = serde.parse(buffer);
+    } catch (error) {
+      this.socket.destroy(error);
+      return false;
+    }
+    this.emit('message', result);
+    return true;
+  }
+
+  _checkBufferSize() {
+    if (this._buffer.length > MAX_MESSAGE_SIZE) {
       this.emit('error', new Error('Maximal message size exceeded'));
     }
   }

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -19,10 +19,9 @@ class Transport extends EventEmitter {
     super();
 
     this.socket = socket;
-    this._buffer = '';
+    this._buffer = null;
     this._uncorkSocket = this.socket.uncork.bind(this.socket);
 
-    this.socket.setEncoding('utf8');
     this.socket.on('data', this._onSocketData.bind(this));
 
     common.forwardMultipleEvents(this.socket, this, ['error', 'close']);
@@ -62,13 +61,26 @@ class Transport extends EventEmitter {
   //
   _onSocketData(chunk) {
     const messages = [];
-    this._buffer += chunk;
+    let parsedLength;
+
+    if (this._buffer) {
+      this._buffer = Buffer.concat([this._buffer, chunk],
+        this._buffer.length + chunk.length);
+    } else {
+      this._buffer = chunk;
+    }
 
     try {
-      this._buffer = serde.parseNetworkMessages(this._buffer, messages);
+      parsedLength = serde.parseNetworkMessages(this._buffer, messages);
     } catch (error) {
       this.socket.destroy(error);
       return;
+    }
+
+    if (this._buffer.length === parsedLength) {
+      this._buffer = null;
+    } else {
+      this._buffer = this._buffer.slice(parsedLength);
     }
 
     const messagesCount = messages.length;
@@ -76,7 +88,7 @@ class Transport extends EventEmitter {
       this.emit('message', messages[i]);
     }
 
-    if (this._buffer.length > MAX_MESSAGE_SIZE) {
+    if (this._buffer && this._buffer.length > MAX_MESSAGE_SIZE) {
       this.emit('error', new Error('Maximal message size exceeded'));
     }
   }

--- a/src/message_parser.h
+++ b/src/message_parser.h
@@ -4,6 +4,8 @@
 #ifndef SRC_MESSAGE_PARSER_H_
 #define SRC_MESSAGE_PARSER_H_
 
+#include <cstddef>
+
 #include <v8.h>
 
 namespace jstp {
@@ -13,8 +15,8 @@ namespace message_parser {
 // Efficiently parses JSTP messages for transports that require message
 // delimiters eliminating the need to split the stream data into parts before
 // parsing and allowing to do that in one pass.
-v8::Local<v8::String> ParseNetworkMessages(v8::Isolate* isolate,
-    const v8::String::Utf8Value& in, v8::Local<v8::Array> out);
+v8::Local<v8::Integer> ParseNetworkMessages(v8::Isolate* isolate,
+    const char* str, std::size_t length, v8::Local<v8::Array> out);
 
 }  // namespace message_parser
 

--- a/src/node_bindings.cc
+++ b/src/node_bindings.cc
@@ -16,6 +16,7 @@ using v8::Local;
 using v8::Object;
 using v8::String;
 using v8::Value;
+using v8::Uint8Array;
 
 namespace jstp {
 
@@ -28,15 +29,27 @@ void Parse(const FunctionCallbackInfo<Value>& args) {
     THROW_EXCEPTION(TypeError, "Wrong number of arguments");
     return;
   }
-  if (!args[0]->IsString() && !args[0]->IsUint8Array()) {
+
+  HandleScope scope(isolate);
+
+  Local<Value> result;
+  std::size_t length;
+
+  if (args[0]->IsString()) {
+    String::Utf8Value utf8str(args[0]);
+    length = utf8str.length();
+    result = jstp::parser::Parse(isolate, *utf8str, length);
+  } else if (args[0]->IsUint8Array()) {
+    Local<Uint8Array> buf = args[0].As<Uint8Array>();
+    length = buf->ByteLength();
+    void* data = buf->Buffer()->GetContents().Data();
+    const char* str = static_cast<const char*>(data) + buf->ByteOffset();
+    result = jstp::parser::Parse(isolate, str, length);
+  } else {
     THROW_EXCEPTION(TypeError, "Wrong argument type");
     return;
   }
 
-  HandleScope scope(isolate);
-
-  String::Utf8Value str(args[0]->ToString());
-  auto result = jstp::parser::Parse(isolate, str);
   args.GetReturnValue().Set(result);
 }
 

--- a/src/node_bindings.cc
+++ b/src/node_bindings.cc
@@ -60,16 +60,20 @@ void ParseNetworkMessages(const FunctionCallbackInfo<Value>& args) {
     THROW_EXCEPTION(TypeError, "Wrong number of arguments");
     return;
   }
-  if (!args[0]->IsString() || !args[1]->IsArray()) {
+  if (!args[0]->IsUint8Array() || !args[1]->IsArray()) {
     THROW_EXCEPTION(TypeError, "Wrong argument type");
     return;
   }
 
   HandleScope scope(isolate);
 
-  String::Utf8Value str(args[0]->ToString());
+  Local<Uint8Array> buf = args[0].As<Uint8Array>();
+  std::size_t length = buf->ByteLength();
+  void* data = buf->Buffer()->GetContents().Data();
+  const char* str = static_cast<const char*>(data) + buf->ByteOffset();
   auto array = args[1].As<Array>();
-  auto result = jstp::message_parser::ParseNetworkMessages(isolate, str, array);
+  auto result = jstp::message_parser::ParseNetworkMessages(isolate,
+      str, length, array);
   args.GetReturnValue().Set(result);
 }
 

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -84,9 +84,7 @@ static constexpr MaybeLocal<Value> (*kParseFunctions[])(Isolate*,
   &internal::ParseObject
 };
 
-Local<Value> Parse(Isolate* isolate, const String::Utf8Value& in) {
-  const char* str = *in;
-  const size_t length = in.length();
+Local<Value> Parse(Isolate* isolate, const char* str, size_t length) {
   const char* end = str + length;
 
   Type type;

--- a/src/parser.h
+++ b/src/parser.h
@@ -15,7 +15,8 @@ namespace parser {
 // Deserializes a UTF-8 encoded string into a JavaScript value
 // and returns a handle to it.
 v8::Local<v8::Value> Parse(v8::Isolate* isolate,
-                           const v8::String::Utf8Value& in);
+                           const char* str,
+                           std::size_t length);
 
 namespace internal {
 

--- a/test/fixtures/message-parser.js
+++ b/test/fixtures/message-parser.js
@@ -5,24 +5,24 @@ module.exports = [
     name: 'a half-message',
     message: '{a:',
     result: [],
-    remainder: '{a:',
+    parsedLength: 0,
   },
   {
     name: 'a whole message',
     message: '{a:1}\0',
     result: [{ a: 1 }],
-    remainder: '',
+    parsedLength: 6,
   },
   {
     name: 'whole message followed by a half-message',
     message: '{a:1}\0{b:',
     result: [{ a: 1 }],
-    remainder: '{b:',
+    parsedLength: 6,
   },
   {
     name: 'a whole message followed by a whole message',
     message: '{a:1}\0{b:2}\0',
     result: [{ a: 1 }, { b: 2 }],
-    remainder: '',
+    parsedLength: 12,
   },
 ];

--- a/test/node/message-parser.js
+++ b/test/node/message-parser.js
@@ -7,10 +7,11 @@ const testCases = require('../fixtures/message-parser');
 
 testCases.forEach((testCase) => {
   const result = [];
-  const remainder = jstp.parseNetworkMessages(testCase.message, result);
+  const parsedLength = jstp.parseNetworkMessages(Buffer.from(testCase.message),
+    result);
   test(`must properly parse ${testCase.name}`, (test) => {
     test.strictSame(result, testCase.result);
-    test.strictSame(remainder, testCase.remainder);
+    test.strictSame(parsedLength, testCase.parsedLength);
     test.end();
   });
 });


### PR DESCRIPTION
* Optimize parser by using Buffers without conversion to string when possible and avoiding calling ToString when parsing strings.
* Change socket to work with Buffers instead of strings to avoid unneeded multiple conversion.
* Refactor (reimplement) parseNetworkPackets function to make it more verbose, improving readability, and change it to work on Buffers instead of strings.
* Avoid excessive copying in cases when messages are divided and being received by parts (experimental).

This PR somewhat experimental in some parts (mostly `lib/socket.js` changes) and is open to comments with better ideas on how to improve it.