### PR TITLE
test: enable tests for js parser implementation

### DIFF
--- a/test/node/serde.js
+++ b/test/node/serde.js
@@ -3,6 +3,7 @@
 const test = require('tap').test;
 
 const jstp = require('../..');
+const jsParser = require('../../lib/serde-fallback');
 
 const testCases = require('../fixtures/serde-test-cases');
 
@@ -14,15 +15,29 @@ testCases.serde.concat(testCases.serialization).forEach((testCase) => {
 });
 
 testCases.serde.concat(testCases.deserialization).forEach((testCase) => {
-  test(`must deserialize ${testCase.name}`, (test) => {
-    test.strictSame(jstp.parse(testCase.serialized), testCase.value);
-    test.end();
-  });
+  const runTest = (parserName, parser) => {
+    test(
+      `must deserialize ${testCase.name} using ${parserName} parser`,
+      (test) => {
+        test.strictSame(parser.parse(testCase.serialized), testCase.value);
+        test.end();
+      }
+    );
+  };
+  runTest('native', jstp);
+  runTest('js', jsParser);
 });
 
 testCases.invalid.forEach((testCase) => {
-  test(`must not allow ${testCase.name}`, (test) => {
-    test.throws(() => jstp.parse(testCase.value));
-    test.end();
-  });
+  const runTest = (parserName, parser) => {
+    test(
+      `must not allow ${testCase.name} using ${parserName} parser`,
+      (test) => {
+        test.throws(() => parser.parse(testCase.value));
+        test.end();
+      }
+    );
+  };
+  runTest('native', jstp);
+  runTest('js', jsParser);
 });

--- a/test/todo/serde.js
+++ b/test/todo/serde.js
@@ -1,15 +1,23 @@
 'use strict';
 
 const jstp = require('../..');
+const jsParser = require('../../lib/serde-fallback');
 
 const test = require('tap').test;
 const testCases = require('../fixtures/todo/serde');
 
 testCases.deserialization.forEach((testCase) => {
-  test(`must deserialize ${testCase.name}`, (test) => {
-    test.strictSame(jstp.parse(testCase.serialized), testCase.value);
-    test.end();
-  });
+  const runTest = (parserName, parser) => {
+    test(
+      `must deserialize ${testCase.name} using ${parserName} parser`,
+      (test) => {
+        test.strictSame(parser.parse(testCase.serialized), testCase.value);
+        test.end();
+      }
+    );
+  };
+  runTest('native', jstp);
+  runTest('js', jsParser);
 });
 
 testCases.serialization.forEach((testCase) => {


### PR DESCRIPTION
The TODO tests were only launched using the default parser
implementation (which should be the native one while developing locally,
and is always the native one on CI since it fails the build if it
doesn't succeed building the addon).  This commit makes the tests run
with both implementations, the default and the fallback JavaScript-only
one.