### PR TITLE
test: rewrite the Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,17 @@
 language: node_js
+
 node_js:
-  - "6.0"
-  - "6.1"
-  - "6.2"
-  - "6.3"
-  - "6.4"
-  - "6.5"
-  - "6.6"
-  - "6.7"
-  - "6.8"
-  - "6.9"
-  - "6.10"
-  - "6.11"
-  - "7.0"
-  - "7.1"
-  - "7.2"
-  - "7.3"
-  - "7.4"
-  - "7.5"
-  - "7.6"
-  - "7.7"
-  - "7.8"
-  - "7.9"
-  - "7.10"
-  - "8.0"
-  - "8.1"
-env:
-  - CXX=g++-6
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-6
-  firefox: latest
-before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+  - 6
+  - 7
+  - 8
+
+os:
+  - linux
+  - osx
+
+dist: trusty
+sudo: false
+osx_image: xcode8.3
+
 script:
   - npm test


### PR DESCRIPTION
* Use only latests releases of Node.js 6.x, 7.x and 8.x.
* Update Ubuntu from Precise to Trusty.
* Don't install a custom compiler, Trusty already has one that should
  support C++11.
* Run tests on macOS too.
* Don't install Firefox and don't launch the fake X server since we
  don't currently have browser tests anymore.  When we do, it will
  require to rewrite that part of the config in a cross-platform manner.

Fixes: https://github.com/metarhia/jstp/issues/262
Refs: https://github.com/metarhia/jstp/pull/260#issuecomment-316951017