### PR TITLE
build: fix building with Node.js 6 on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,16 @@ node_js:
   - "7.10"
   - "8.0"
   - "8.1"
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.3
+      node_js: 6
+      env:
+    - os: osx
+      osx_image: xcode8.3
+      node_js: 8
+      env:
 env:
   - CXX=g++-6
 addons:
@@ -35,7 +45,7 @@ addons:
       - g++-6
   firefox: latest
 before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export DISPLAY=:99.0; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh -e /etc/init.d/xvfb start; fi
 script:
   - npm test

--- a/binding.gyp
+++ b/binding.gyp
@@ -50,7 +50,10 @@
       },
       'cflags_cc': ['<@(jstp_base_ccflags)'],
       'xcode_settings': {
-        'OTHER_CPLUSPLUSFLAGS': ['<@(jstp_base_ccflags)']
+        'OTHER_CPLUSPLUSFLAGS': [
+          '<@(jstp_base_ccflags)',
+          '-stdlib=libc++'
+        ]
       }
     }
   ]


### PR DESCRIPTION
Node.js 6.11.1 bundles npm 3.10.10, which bundles node-gyp 3.4.0.  The
problem with this version is that it doesn't emit `-stdlib=libc++` as
one of clang flags by default, which causes it to use old GCC 4.2
headers instead of clang headers.  Because of that, compilation fails
with:

    ../src/parser.cc:10:10: fatal error: 'cstdint' file not found

This patch adds the flag to `OTHER_CPLUSPLUSFLAGS`.  It causes no harm
when using newer node-gyp because duplicate flags are ignored, but
enables building JSTP with vanilla Node.js 6.x on macOS.