### PR TITLE
doc: add AppVeyor and Coveralls badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,6 @@
     src="https://www.bithound.io/github/metarhia/jstp/badges/score.svg"
     alt="bitHound Score"
   /></a>
-  <br />
-  <a href="https://badge.fury.io/js/metarhia-jstp"><img
-    src="https://badge.fury.io/js/metarhia-jstp.svg"
-    alt="NPM Version"
-  /></a>
-  <a href="https://www.npmjs.com/package/metarhia-jstp"><img
-    src="https://img.shields.io/npm/dm/metarhia-jstp.svg"
-    alt="NPM Downloads/Month"
-  /></a>
-  <a href="https://www.npmjs.com/package/metarhia-jstp"><img
-    src="https://img.shields.io/npm/dt/metarhia-jstp.svg"
-    alt="NPM Downloads"
-  /></a>
   <h1>JSTP / JavaScript Transfer Protocol</h1>
 </div>
 
@@ -54,7 +41,21 @@ implementation bundled in!
 
 **This project is bound by a [Code of Conduct](CODE_OF_CONDUCT.md).**
 
-## Installation
+<div align="center">
+  <h2>Installation</h2>
+  <a href="https://badge.fury.io/js/metarhia-jstp"><img
+    src="https://badge.fury.io/js/metarhia-jstp.svg"
+    alt="NPM Version"
+  /></a>
+  <a href="https://www.npmjs.com/package/metarhia-jstp"><img
+    src="https://img.shields.io/npm/dm/metarhia-jstp.svg"
+    alt="NPM Downloads/Month"
+  /></a>
+  <a href="https://www.npmjs.com/package/metarhia-jstp"><img
+    src="https://img.shields.io/npm/dt/metarhia-jstp.svg"
+    alt="NPM Downloads"
+  /></a>
+</div>
 
 JSTP works in Node.js and web browsers:
 
@@ -73,7 +74,7 @@ We also have official client-side implementations for
 [Java](https://github.com/metarhia/jstp-java)
 that work effortlessly on iOS and Android 🎉
 
-## Getting Started
+<h2 align="center">Getting Started</h2>
 
 Server:
 
@@ -142,7 +143,7 @@ function handleConnect(error, connection, app) {
 }
 ```
 
-## Project Maintainers
+<h2 align="center">Project Maintainers</h2>
 
 Kudos to [@tshemsedinov](https://github.com/tshemsedinov) for the initial idea
 and proof-of-concept implementation. Current project team is:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@
     src="https://travis-ci.org/metarhia/jstp.svg?branch=master"
     alt="Travis CI"
   /></a>
+  <a href="https://ci.appveyor.com/project/metarhia/jstp"><img
+    src="https://ci.appveyor.com/api/projects/status/rev863t5a909ltuq/branch/master?svg=true"
+    alt="AppVeyor CI"
+  /></a>
+  <a href="https://coveralls.io/github/metarhia/jstp?branch=master"><img
+    src="https://coveralls.io/repos/github/metarhia/jstp/badge.svg?branch=master"
+    alt="Coverage Status"
+  /></a>
   <a
     href="https://www.bithound.io/github/metarhia/jstp/master/dependencies/npm"
   ><img
@@ -20,6 +28,7 @@
     src="https://www.bithound.io/github/metarhia/jstp/badges/score.svg"
     alt="bitHound Score"
   /></a>
+  <br />
   <a href="https://badge.fury.io/js/metarhia-jstp"><img
     src="https://badge.fury.io/js/metarhia-jstp.svg"
     alt="NPM Version"


### PR DESCRIPTION
Add AppVeyor and Coveralls to `README.md`, and redesign the page a bit to handle more badges.