### PR TITLE
lint: use handle-callback-err rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -55,6 +55,9 @@ rules:
   func-call-spacing:
     - error
     - never
+  handle-callback-err:
+    - error
+    - '^.*(e|E)rr'
   key-spacing:
     - error
     - beforeColon: false


### PR DESCRIPTION
Make linter reinforce error handling in callbacks.