### PR TITLE
deps: add missing uuid dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7413,8 +7413,7 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-      "dev": true
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "./lib/simple-auth-policy.js": false
   },
   "dependencies": {
+    "uuid": "^3.1.0",
     "websocket": "^1.0.24"
   },
   "devDependencies": {


### PR DESCRIPTION
Add a missing dependency to package.json.

The package was located in the tree as a deduplicated transitive
dependency, so it went unnoticed until the tree changed its shape in
https://github.com/metarhia/jstp/pull/277