### PR TITLE
lib: allow to set event handlers in application

### DIFF
--- a/lib/applications.js
+++ b/lib/applications.js
@@ -13,16 +13,21 @@ const errors = require('./errors');
 //   api - object that contains interfaces as its fields each of which
 //         contains functions by method names. Each method has the following
 //         signature (connection, <0 or more method arguments>, callback)
-//   version - application version of 'name' application
+//   eventHandlers - object that contains interfaces as its fields each
+//                   of which contains functions by event names. Each method
+//                   has the following signature
+//                   (connection, <0 or more event arguments>)
+//   version - application version of 'name' application (optional)
 //
 class Application {
-  constructor(name, api, version) {
+  constructor(name, api, eventHandlers, version) {
     [this.name, this.version] = common.rsplit(name, '@');
     if (!this.version) this.version = version;
     if (this.version && !semver.valid(this.version)) {
       throw new TypeError('Invalid semver version');
     }
     this.api = api;
+    this.eventHandlers = eventHandlers;
   }
 
   // Call application method
@@ -59,6 +64,19 @@ class Application {
   getMethods(interfaceName) {
     const appInterface = this.api[interfaceName];
     return appInterface && Object.keys(appInterface);
+  }
+
+  // Handle incoming event
+  //   connection - JSTP connection that received event
+  //   interfaceName - name of the interface
+  //   eventName - name of the event
+  //   args - event arguments
+  //
+  handleEvent(connection, interfaceName, eventName, args) {
+    if (this.eventHandlers) {
+      const handler = this.eventHandlers[interfaceName][eventName];
+      if (handler) handler(connection, ...args);
+    }
   }
 }
 

--- a/lib/applications.js
+++ b/lib/applications.js
@@ -20,7 +20,7 @@ const errors = require('./errors');
 //   version - application version of 'name' application (optional)
 //
 class Application {
-  constructor(name, api, eventHandlers, version) {
+  constructor(name, api, eventHandlers = {}, version) {
     [this.name, this.version] = common.rsplit(name, '@');
     if (!this.version) this.version = version;
     if (this.version && !semver.valid(this.version)) {
@@ -73,8 +73,9 @@ class Application {
   //   args - event arguments
   //
   handleEvent(connection, interfaceName, eventName, args) {
-    if (this.eventHandlers) {
-      const handler = this.eventHandlers[interfaceName][eventName];
+    const handlerInterface = this.eventHandlers[interfaceName];
+    if (handlerInterface) {
+      const handler = handlerInterface[eventName];
       if (handler) handler(connection, ...args);
     }
   }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -601,6 +601,8 @@ class Connection extends EventEmitter {
     if (remoteProxy) {
       remoteProxy._emitLocal(eventName, eventArgs);
     }
+
+    this.application.handleEvent(this, interfaceName, eventName, eventArgs);
   }
 
   // Process incoming inspect message

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -602,7 +602,9 @@ class Connection extends EventEmitter {
       remoteProxy._emitLocal(eventName, eventArgs);
     }
 
-    this.application.handleEvent(this, interfaceName, eventName, eventArgs);
+    if (this.application && this.application.handleEvent) {
+      this.application.handleEvent(this, interfaceName, eventName, eventArgs);
+    }
   }
 
   // Process incoming inspect message

--- a/test/node/api-versions.js
+++ b/test/node/api-versions.js
@@ -30,8 +30,8 @@ const interfacesVLatest = {
   },
 };
 
-const appV1 = new jstp.Application(app.name, interfacesV1, null, '1.0.0');
-const appV2 = new jstp.Application(app.name, interfacesV2, null, '2.0.0');
+const appV1 = new jstp.Application(app.name, interfacesV1, {}, '1.0.0');
+const appV2 = new jstp.Application(app.name, interfacesV2, {}, '2.0.0');
 const appVlatest = new jstp.Application(app.name, interfacesVLatest);
 
 let server;
@@ -223,7 +223,7 @@ test.test('must throw an error on invalid version in application name',
 test.test('must throw an error on invalid version in application parameter',
   (test) => {
     test.throws(() => {
-      new jstp.Application('app', interfacesV1, null, '__invalid__');
+      new jstp.Application('app', interfacesV1, {}, '__invalid__');
     }, TypeError, 'Invalid semver version');
     test.end();
   }

--- a/test/node/api-versions.js
+++ b/test/node/api-versions.js
@@ -30,8 +30,8 @@ const interfacesVLatest = {
   },
 };
 
-const appV1 = new jstp.Application(app.name, interfacesV1, '1.0.0');
-const appV2 = new jstp.Application(app.name, interfacesV2, '2.0.0');
+const appV1 = new jstp.Application(app.name, interfacesV1, null, '1.0.0');
+const appV2 = new jstp.Application(app.name, interfacesV2, null, '2.0.0');
 const appVlatest = new jstp.Application(app.name, interfacesVLatest);
 
 let server;
@@ -223,7 +223,7 @@ test.test('must throw an error on invalid version in application name',
 test.test('must throw an error on invalid version in application parameter',
   (test) => {
     test.throws(() => {
-      new jstp.Application('app', interfacesV1, '__invalid__');
+      new jstp.Application('app', interfacesV1, null, '__invalid__');
     }, TypeError, 'Invalid semver version');
     test.end();
   }

--- a/test/node/application-event-handlers.js
+++ b/test/node/application-event-handlers.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const test = require('tap');
+
+const jstp = require('../..');
+
+const app = require('../fixtures/application');
+
+let server;
+let connection;
+
+test.afterEach((done) => {
+  if (connection) {
+    connection.close();
+    connection = null;
+  }
+  if (server) server.close();
+  done();
+});
+
+test.test('must call event handler in application on remote event', (test) => {
+  const expectedName = 'name';
+
+  const eventHandlers = {
+    someService: {
+      name: (connection, name) => {
+        test.assert(connection, 'must pass connection to event handler');
+        test.equals(name, expectedName, 'must pass correct argument');
+        test.end();
+      },
+    },
+  };
+  const application = new jstp.Application(app.name, {}, eventHandlers);
+  server = jstp.net.createServer([application]);
+  server.listen(0, () => {
+    const port = server.address().port;
+    jstp.net.connect(app.name, null, port, (error, conn) => {
+      connection = conn;
+      test.assertNot(error, 'must connect to server and perform handshake');
+      connection.emitRemoteEvent('someService', 'name', [expectedName]);
+    });
+  });
+});

--- a/test/node/application-event-handlers.js
+++ b/test/node/application-event-handlers.js
@@ -23,7 +23,7 @@ test.test('must call event handler in application on remote event', (test) => {
 
   const eventHandlers = {
     someService: {
-      name: (connection, name) => {
+      name(connection, name) {
         test.assert(connection, 'must pass connection to event handler');
         test.equals(name, expectedName, 'must pass correct argument');
         test.end();


### PR DESCRIPTION
As the name states you can now set event handlers in the application itself, this will gradually improve server side code as you won't need to manually set `event` handlers on each connection.