### PR TITLE
server: fix handshake timeout logic

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -84,11 +84,18 @@ class Server {
       this.emit('connectionError', error, connection);
     });
 
-    connection.setTimeout(HANDSHAKE_TIMEOUT, () => {
+    const handleTimeout = () => {
       if (!connection.handshakeDone) {
         connection.close();
         this.emit('handshakeTimeout', connection);
-      } else if (this.heartbeatInterval) {
+      }
+    };
+
+    connection.setTimeout(HANDSHAKE_TIMEOUT, handleTimeout);
+
+    connection.on('client', () => {
+      connection.clearTimeout(handleTimeout);
+      if (this.heartbeatInterval) {
         connection.startHeartbeat(this.heartbeatInterval);
       }
     });

--- a/test/node/regress-gh-217.js
+++ b/test/node/regress-gh-217.js
@@ -1,0 +1,31 @@
+// Regression test for https://github.com/metarhia/jstp/issues/217
+
+'use strict';
+
+const tap = require('tap');
+const jstp = require('../..');
+
+const HANDSHAKE_TIMEOUT = 3000;
+
+const app = new jstp.Application('app', {});
+const server = jstp.net.createServer({
+  applications: [app],
+  heartbeatInterval: 100,
+});
+
+tap.plan(1);
+
+server.listen(() => {
+  jstp.net.connect(
+    'app', null, server.address().port,
+    (error, connection) => {
+      tap.assertNot(error, 'client must connect successfully');
+
+      connection.close();
+
+      setTimeout(() => {
+        server.close();
+      }, HANDSHAKE_TIMEOUT + 100);
+    }
+  );
+});

--- a/test/node/regress-gh-217.js
+++ b/test/node/regress-gh-217.js
@@ -1,4 +1,11 @@
 // Regression test for https://github.com/metarhia/jstp/issues/217
+//
+// A confusing thing about this test is that it doesn't seem to have any
+// assertions except the one that tests if `jstp.net.connect()` has succeeded.
+// In fact, the crux of the test is that it just must complete.  When the
+// subject bug is present, it will crash with an unhandled exception.  This
+// exception happens in an asynchronous context, so `tap.doesNotThrow()` isn't
+// used here, tap will handle it top-level via a domain.
 
 'use strict';
 

--- a/test/node/regress-gh-283.js
+++ b/test/node/regress-gh-283.js
@@ -1,0 +1,41 @@
+// Regression test for https://github.com/metarhia/jstp/issues/283
+
+'use strict';
+
+const tap = require('tap');
+const jstp = require('../..');
+
+const HANDSHAKE_TIMEOUT = 3000;
+
+const app = new jstp.Application('app', {});
+const server = jstp.net.createServer({
+  applications: [app],
+  heartbeatInterval: 100,
+});
+
+tap.plan(2);
+
+server.listen(() => {
+  jstp.net.connect(
+    'app', null, server.address().port,
+    (error, connection) => {
+      tap.assertNot(error, 'client must connect successfully');
+
+      let heartbeatsCount = 0;
+
+      connection.on('heartbeat', () => {
+        heartbeatsCount++;
+      });
+
+      setTimeout(() => {
+        tap.assert(
+          heartbeatsCount > 0,
+          'client must have received some heartbeat messages'
+        );
+
+        connection.close();
+        server.close();
+      }, HANDSHAKE_TIMEOUT - 100);
+    }
+  );
+});


### PR DESCRIPTION
Clear handshake timeout on successful handshake and start sending
heartbeat messages on successful handshake handler instead of handshake
timeout handler.

Fixes: https://github.com/metarhia/jstp/issues/217
Fixes: https://github.com/metarhia/jstp/issues/283