### PR TITLE
connection: use ping-pong instead of heartbeat

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -236,7 +236,7 @@ class Connection extends EventEmitter {
 
   // Send a pong message
   //
-  pong(messageId) {
+  _pong(messageId) {
     if (this._closed) {
       return;
     }
@@ -252,10 +252,7 @@ class Connection extends EventEmitter {
       if (this._closed) {
         return;
       }
-      const pingId = this._nextMessageId;
-      this.ping(() => {
-        this.session.unbufferUpTo(pingId);
-      });
+      this.ping();
     };
 
     this._heartbeatInterval = setInterval(heartbeat, interval);
@@ -683,7 +680,7 @@ class Connection extends EventEmitter {
   //
   _processPingMessage(message) {
     const messageId = message.ping[0];
-    this.pong(messageId);
+    this._pong(messageId);
     this.session._onMessageRecieved(messageId);
   }
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -52,7 +52,7 @@ class Connection extends EventEmitter {
     this.application = null;
     this.remoteProxies = {};
 
-    this._heartbeatInterval = null;
+    this._heartbeatTimer = null;
     this._closed = false;
 
     // Defined in constructor to be used as default callback in callMethod
@@ -249,21 +249,20 @@ class Connection extends EventEmitter {
   //
   startHeartbeat(interval) {
     const heartbeat = () => {
-      if (this._closed) {
-        return;
+      if (!this._closed) {
+        this.ping();
       }
-      this.ping();
     };
 
-    this._heartbeatInterval = setInterval(heartbeat, interval);
+    this._heartbeatTimer = setInterval(heartbeat, interval);
   }
 
   // Stop sending ping messages
   //
   stopHeartbeat() {
-    if (this._heartbeatInterval) {
-      clearTimeout(this._heartbeatInterval);
-      this._heartbeatInterval = null;
+    if (this._heartbeatTimer) {
+      clearTimeout(this._heartbeatTimer);
+      this._heartbeatTimer = null;
     }
   }
 
@@ -374,7 +373,7 @@ class Connection extends EventEmitter {
   // Closed socket event handler
   //
   _onSocketClose() {
-    this.closed = true;
+    this._closed = true;
     this.stopHeartbeat();
     this.emit('close', this);
     if (this.server) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -2,7 +2,6 @@
 
 const { EventEmitter } = require('events');
 const semver = require('semver');
-const timers = require('timers');
 
 const common = require('./common');
 const serde = require('./serde');
@@ -53,17 +52,14 @@ class Connection extends EventEmitter {
     this.application = null;
     this.remoteProxies = {};
 
-    this._heartbeatCallbackInstance = null;
+    this._heartbeatInterval = null;
+    this._closed = false;
 
     // Defined in constructor to be used as default callback in callMethod
     // without binding it.
     this._emitError = (error) => {
       if (error) this.emit('error', error);
     };
-
-    // Defined in constructor to be used as heartbeat message
-    // in debug mode events
-    this._heartbeatMessage = {};
 
     transport.on('message', this._processMessage.bind(this));
     transport.on('close', this._onSocketClose.bind(this));
@@ -241,33 +237,36 @@ class Connection extends EventEmitter {
   // Send a pong message
   //
   pong(messageId) {
+    if (this._closed) {
+      return;
+    }
     const message = { pong: [messageId] };
     this._send(this._prepareMessage(message), message);
   }
 
-  // Start sending heartbeat messages
+  // Start sending ping messages
   //   interval - heartbeat interval in milliseconds
   //
   startHeartbeat(interval) {
-    const callback = () => {
-      this.transport.send('{}');
-      this.setTimeout(interval, this._heartbeatCallbackInstance);
-
-      if (process.env.NODE_ENV !== 'production') {
-        this.emit('heartbeat', this._heartbeatMessage);
+    const heartbeat = () => {
+      if (this._closed) {
+        return;
       }
+      const pingId = this._nextMessageId;
+      this.ping(() => {
+        this.session.unbufferUpTo(pingId);
+      });
     };
 
-    this._heartbeatCallbackInstance = callback;
-    callback();
+    this._heartbeatInterval = setInterval(heartbeat, interval);
   }
 
-  // Stop sending heartbeat messages
+  // Stop sending ping messages
   //
   stopHeartbeat() {
-    if (this._heartbeatCallbackInstance) {
-      this.clearTimeout(this._heartbeatCallbackInstance);
-      this._heartbeatCallbackInstance = null;
+    if (this._heartbeatInterval) {
+      clearTimeout(this._heartbeatInterval);
+      this._heartbeatInterval = null;
     }
   }
 
@@ -320,38 +319,15 @@ class Connection extends EventEmitter {
   // Close the connection
   //
   close() {
+    this._closed = true;
     this.stopHeartbeat();
     this.transport.end();
-  }
-
-  // Set a timeout using timers.enroll()
-  //   milliseconds - amount of milliseconds
-  //   callback - callback function
-  //
-  setTimeout(milliseconds, callback) {
-    timers.enroll(this, milliseconds);
-    timers._unrefActive(this);
-    this.once('_timeout', callback);
-  }
-
-  // Clear a timeout set with Connection#setTimeout
-  //   handler - timer callback to remove
-  //
-  clearTimeout(handler) {
-    timers.unenroll(this);
-    this.removeListener('_timeout', handler);
   }
 
   // Returns underlying transport
   //
   getTransport() {
     return this.transport.getRawTransport();
-  }
-
-  // timers.enroll() timeout handler
-  //
-  _onTimeout() {
-    this.emit('_timeout');
   }
 
   // Prepare a JSTP message to be sent over this connection
@@ -383,6 +359,7 @@ class Connection extends EventEmitter {
   //   message - a message to send (optional)
   //
   _end(message) {
+    this._closed = true;
     this.stopHeartbeat();
 
     if (message) {
@@ -400,6 +377,7 @@ class Connection extends EventEmitter {
   // Closed socket event handler
   //
   _onSocketClose() {
+    this.closed = true;
     this.stopHeartbeat();
     this.emit('close', this);
     if (this.server) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -161,10 +161,10 @@ class Server {
       }
     };
 
-    connection.setTimeout(HANDSHAKE_TIMEOUT, handleTimeout);
+    const handshakeTimeout = setTimeout(handleTimeout, HANDSHAKE_TIMEOUT);
 
     connection.on('client', () => {
-      connection.clearTimeout(handleTimeout);
+      clearTimeout(handshakeTimeout);
       if (this.heartbeatInterval) {
         connection.startHeartbeat(this.heartbeatInterval);
       }

--- a/lib/session.js
+++ b/lib/session.js
@@ -26,6 +26,12 @@ class Session extends Map {
     Object.preventExtensions(this);
   }
 
+  unbufferUpTo(id) {
+    for (let i = this.guaranteedDeliveredCount + 1; i <= id; i++) {
+      this.buffer.delete(i);
+    }
+  }
+
   _bufferMessage(id, message) {
     this.buffer.set(Math.abs(id), message);
     this.latestBufferedMessageId = id;
@@ -47,10 +53,8 @@ class Session extends Map {
     if (this.connection) {
       this.connection.close();
     }
+    this.unbufferUpTo(recievedCount);
     this.connection = newConnection;
-    for (let i = this.guaranteedDeliveredCount + 1; i <= recievedCount; i++) {
-      this.buffer.delete(i);
-    }
     this.guaranteedDeliveredCount = recievedCount;
   }
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -26,12 +26,6 @@ class Session extends Map {
     Object.preventExtensions(this);
   }
 
-  unbufferUpTo(id) {
-    for (let i = this.guaranteedDeliveredCount + 1; i <= id; i++) {
-      this.buffer.delete(i);
-    }
-  }
-
   _bufferMessage(id, message) {
     this.buffer.set(Math.abs(id), message);
     this.latestBufferedMessageId = id;
@@ -53,8 +47,10 @@ class Session extends Map {
     if (this.connection) {
       this.connection.close();
     }
-    this.unbufferUpTo(recievedCount);
     this.connection = newConnection;
+    for (let i = this.guaranteedDeliveredCount + 1; i <= recievedCount; i++) {
+      this.buffer.delete(i);
+    }
     this.guaranteedDeliveredCount = recievedCount;
   }
 

--- a/test/node/regress-gh-283.js
+++ b/test/node/regress-gh-283.js
@@ -23,8 +23,10 @@ server.listen(() => {
 
       let heartbeatsCount = 0;
 
-      connection.on('heartbeat', () => {
-        heartbeatsCount++;
+      connection.on('incomingMessage', (message) => {
+        if (message.ping !== undefined) {
+          heartbeatsCount++;
+        }
       });
 
       setTimeout(() => {


### PR DESCRIPTION
* Send Ping-Pong instead of Heartbeat messages.
* Use setInterval() instead of timers.enroll().
* Rewrite tests.

Fixes: #217 