### PR TITLE
connection: make callback method private

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -90,7 +90,7 @@ class Connection extends EventEmitter {
   //   error - error that has occured or null
   //   result - result of a remote method if there was no error
   //
-  callback(messageId, error, result) {
+  _callback(messageId, error, result) {
     let message;
 
     if (error) {
@@ -617,9 +617,9 @@ class Connection extends EventEmitter {
 
     const methods = this.application.getMethods(interfaceName);
     if (methods) {
-      this.callback(messageId, null, methods);
+      this._callback(messageId, null, methods);
     } else {
-      this.callback(messageId, errors.ERR_INTERFACE_NOT_FOUND);
+      this._callback(messageId, errors.ERR_INTERFACE_NOT_FOUND);
     }
   }
 
@@ -649,7 +649,7 @@ class Connection extends EventEmitter {
   //   result - data to send back as a result
   //
   _remoteCallbackWrapper(messageId, error, ...result) {
-    this.callback(messageId, error, result);
+    this._callback(messageId, error, result);
   }
 }
 


### PR DESCRIPTION
There's no reason to call it directly outside of the connection's
internal machinery except to break things.

Also, this will make it consistent with `pong` after #303 lands.