### PR TITLE
test: update Travis config to use the current Node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 
 node_js:
   - 6
-  - 7
   - 8
+  - 9
 
 os:
   - linux


### PR DESCRIPTION
Remove end-of-life Node.js 7 and add the current Node.js 9.