### PR TITLE
connection: reject invalid event message

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -657,6 +657,11 @@ class Connection extends EventEmitter {
     this.emit('event', interfaceName, eventName, eventArgs);
     this.session._onMessageReceived(message.event[0]);
 
+    if (!Array.isArray(eventArgs)) {
+      this._rejectMessage(message);
+      return;
+    }
+
     const remoteProxy = this.remoteProxies[interfaceName];
     if (remoteProxy) {
       remoteProxy._emitLocal(eventName, eventArgs);

--- a/test/node/connection-event.js
+++ b/test/node/connection-event.js
@@ -80,6 +80,25 @@ test.test('client must process an event', (test) => {
   });
 });
 
+test.test('connection must reject events having not array as arguments',
+  (test) => {
+    const port = server.address().port;
+    jstp.net.connect(app.name, null, port, (error, conn) => {
+      connection = conn;
+      test.assertNot(error, 'must connect to server');
+
+      connection.on('messageRejected', () => {
+        test.pass('event message must be rejected');
+        test.end();
+      });
+
+      const invalidArgs = { invalid: 0 };
+      server.getClientsArray()[0].emitRemoteEvent(
+        iface, eventName, invalidArgs
+      );
+    });
+  });
+
 test.test('remote proxy must emit an event', (test) => {
   const port = server.address().port;
   jstp.net.connectAndInspect(app.name, null, [iface], port,


### PR DESCRIPTION
Reject event messages having anything other than array provided as event arguments.