### PR TITLE
lib: fix incorrect comment

### DIFF
--- a/lib/simple-session-storage-provider.js
+++ b/lib/simple-session-storage-provider.js
@@ -41,8 +41,8 @@ class SimpleSessionStorageProvider extends Map {
   }
 
   // Must save the Session object with the corresponding session id.
-  // This method is called once on session creation and every time
-  // when connection associated with session is being closed.
+  // This method is called every time when connection associated with
+  // session is being closed.
   //   sessionId - id of the session to be added
   //   session - Session object to be added
   //


### PR DESCRIPTION
Fix comment explaining SessionStorageProvider interface having an incorrect statement about one of the method calls.