### PR TITLE
lib: add utility for call messages resending

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -123,6 +123,10 @@ class Connection extends EventEmitter {
     return removedTransport;
   }
 
+  _getCallbackId(absId) {
+    return absId * this._messageIdDelta;
+  }
+
   // Send a call message over the connection
   //   interfaceName - name of an interface
   //   methodName - name of a method
@@ -137,6 +141,27 @@ class Connection extends EventEmitter {
     const messageId = message.call[0];
     this._callbacks.set(messageId, callback || this._emitError);
     this._sendWithBuffering(message, messageId);
+  }
+
+  // Send a call message over the connection resending if not possible to
+  // get a callback.
+  //   interfaceName - name of an interface
+  //   methodName - name of a method
+  //   args - method arguments
+  //   callback - callback function that is invoked after a callback message
+  //              has been received
+  //
+  callMethodWithResend(interfaceName, methodName, args, callback) {
+    const cb = (error, ...args) => {
+      if (error === errors.ERR_CALLBACK_LOST) {
+        this.session.connection.callMethodWithResend(
+          interfaceName, methodName, args, callback
+        );
+        return;
+      }
+      callback(error, ...args);
+    };
+    this.callMethod(interfaceName, methodName, args, cb);
   }
 
   // Send a callback message over the connection
@@ -410,6 +435,7 @@ class Connection extends EventEmitter {
   //   message - a message object (used for development events thus optional)
   //
   _send(preparedMessage, message) {
+    if (this._closed) return;
     this.transport.send(preparedMessage);
 
     if (process.env.NODE_ENV !== 'production') {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -2,6 +2,9 @@
 
 const util = require('util');
 
+// Implementation defined errors
+const ERR_CALLBACK_LOST = -1;
+
 // Standard protocol errors
 const ERR_APP_NOT_FOUND = 10;
 const ERR_AUTH_FAILED = 11;
@@ -77,6 +80,7 @@ RemoteError.getJstpArrayFor = (error) => {
 // Default messages for predefined error codes
 //
 RemoteError.defaultMessages = {
+  [ERR_CALLBACK_LOST]:          'Connection closed before receiving callback',
   [ERR_APP_NOT_FOUND]:          'Application not found',
   [ERR_AUTH_FAILED]:            'Authentication failed',
   [ERR_INTERFACE_NOT_FOUND]:    'Interface not found',
@@ -88,6 +92,7 @@ RemoteError.defaultMessages = {
 };
 
 module.exports = {
+  ERR_CALLBACK_LOST,
   ERR_APP_NOT_FOUND,
   ERR_AUTH_FAILED,
   ERR_INTERFACE_NOT_FOUND,

--- a/lib/remote-proxy.js
+++ b/lib/remote-proxy.js
@@ -19,17 +19,24 @@ class RemoteProxy extends EventEmitter {
     methods.filter(method => this[method] === undefined)
       .forEach((method) => {
         this[method] = (...args) => {
-          let callback = args[args.length - 1];
+          let resend = args[args.length - 1];
+          let callback = args[args.length - 2];
 
-          if (typeof(callback) === 'function') {
-            args = Array.prototype.slice.call(args, 0, -1);
+          if (typeof callback === 'function' && typeof resend === 'boolean') {
+            args = args.slice(0, -2);
+          } else if (typeof resend === 'function') {
+            callback = resend;
+            resend = false;
+            args = args.slice(0, -1);
           } else {
             callback = null;
+            resend = false;
           }
 
-          this._connection.callMethod(
-            this._interfaceName, method, args, callback
-          );
+          (resend ?
+            this._connection.callMethodWithResend :
+            this._connection.callMethod
+          ).call(this._connection, this._interfaceName, method, args, callback);
         };
       });
   }

--- a/lib/session.js
+++ b/lib/session.js
@@ -2,6 +2,8 @@
 
 const uuid4 = require('uuid/v4');
 
+const errors = require('./errors');
+
 // JSTP Session class used to buffer and resend the messages on unexpected
 // connection closes.
 // Extends Map class and thus can be used to store the current session state
@@ -91,6 +93,12 @@ class Session extends Map {
     this.connection = newConnection;
     for (let i = this.guaranteedDeliveredCount + 1; i <= receivedCount; i++) {
       this.buffer.delete(i);
+      const id = this.connection._getCallbackId(i);
+      const callback = this.connection._callbacks.get(id);
+      if (callback) {
+        this.connection._callbacks.delete(id);
+        callback(errors.ERR_CALLBACK_LOST);
+      }
     }
     this.guaranteedDeliveredCount = receivedCount;
   }

--- a/lib/transport-common.js
+++ b/lib/transport-common.js
@@ -172,6 +172,9 @@ const newReconnectFn = (
       return;
     }
 
+    if (connection.transport) {
+      connection._removeTransport();
+    }
     // eslint-disable-next-line new-cap
     connection._initTransport(new transportClass(rawConnection));
 

--- a/test/node/remote-error-default-messages.js
+++ b/test/node/remote-error-default-messages.js
@@ -9,5 +9,5 @@ const expectedMessages = Object.keys(jstp)
   .filter(key => key.startsWith('ERR_'))
   .map(key => jstp[key].toString());
 
-test.includes(Object.keys(RemoteError.defaultMessages), expectedMessages,
+test.includes(Object.keys(RemoteError.defaultMessages).sort(), expectedMessages,
   'Must have a default message for every predefined error');

--- a/test/node/resendable-call-from-client.js
+++ b/test/node/resendable-call-from-client.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const test = require('tap');
+
+const cp = require('child_process');
+const path = require('path');
+
+const jstp = require('../..');
+
+const appName = 'application';
+
+const sessionStorage = new Map();
+
+let connection;
+const client = {
+  session: null,
+};
+let initialConnection = true;
+let callsRecievedByServer = 0;
+
+let server = createServer();
+
+function createServer() {
+  const server = cp.fork(
+    path.join(__dirname, '../utils/resendable-call/server.js')
+  );
+
+  server.on('message', ([message, ...args]) => {
+    switch (message) {
+      case 'error':
+        test.fail(args[0].message);
+        break;
+      case 'listening':
+        (initialConnection ? connect : reconnect)(args[0]);
+        break;
+      case 'getSession':
+        server.send([
+          'getSessionResponse',
+          args[0],
+          sessionStorage.get(args[0]),
+        ]);
+        break;
+      case 'setSession':
+        sessionStorage.set(args[0], args[1]);
+        if (initialConnection) {
+          call();
+        }
+        break;
+      case 'callRecieved':
+        if (++callsRecievedByServer !== 1) {
+          test.fail('server must recieve only one call');
+        }
+        break;
+    }
+  });
+
+  return server;
+}
+
+let amountOfCalls = 0;
+function call() {
+  amountOfCalls++;
+  if (amountOfCalls !== 2) {
+    return;
+  }
+  connection.callMethodWithResend('iface', 'method', [], (error) => {
+    test.assertNot(error, 'must not encounter an error');
+
+    connection.close();
+    server.kill('SIGKILL');
+    test.end();
+  });
+  server.kill('SIGKILL');
+  server = createServer();
+}
+
+function connect(port) {
+  jstp.net.connect(
+    appName,
+    client,
+    port,
+    (error, conn, session) => {
+      test.assertNot(error, 'must connect without errors');
+
+      connection = conn;
+      connection.on('error', (error) => {
+        if (error.code !== 'ECONNRESET') {
+          test.fail('must not encounter errors other than `ECONNRESET`');
+        }
+      });
+
+      client.session = session;
+      initialConnection = false;
+
+      call();
+    }
+  );
+}
+
+function reconnect(port) {
+  jstp.net.reconnect(connection, port, (error, conn) => {
+    test.assertNot(error, 'must connect without errors');
+
+    connection = conn;
+    connection.on('error', (error) => {
+      if (error.code !== 'ECONNRESET') {
+        test.fail('must not encounter errors other then `ECONNRESET`');
+      }
+    });
+  });
+}

--- a/test/node/resendable-call-from-closed-client.js
+++ b/test/node/resendable-call-from-closed-client.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const test = require('tap');
+
+const jstp = require('../..');
+
+const appName = 'application';
+const interfaces = {
+  iface: {
+    method: (connection, callback) => {
+      test.pass('must send call only once');
+      callback(null);
+    },
+  },
+};
+
+const application = new jstp.Application(appName, interfaces);
+const serverConfig = { applications: [application] };
+
+const client = { session: null, reconnector: () => {} };
+
+test.plan(4);
+
+const server = jstp.net.createServer(serverConfig);
+server.listen(0, () => {
+  const port = server.address().port;
+  jstp.net.connectAndInspect(
+    appName,
+    client,
+    ['iface'],
+    port,
+    'localhost',
+    (error, connection, api) => {
+      test.assertNot(error, 'must connect to server');
+
+      connection.close();
+      api.iface.method((error) => {
+        test.assertNot(error, 'must not return an error');
+        connection.close();
+        server.close();
+      }, true);
+
+      const port = server.address().port;
+
+      jstp.net.reconnect(connection, port, 'localhost', (error, conn) => {
+        test.assertNot(error, 'must reconnect to server');
+        connection = conn;
+      });
+    }
+  );
+});

--- a/test/node/resendable-call-from-server-to-closed-client.js
+++ b/test/node/resendable-call-from-server-to-closed-client.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const test = require('tap');
+
+const jstp = require('../..');
+
+const appName = 'application';
+const interfaces = {
+  iface: {
+    method: (connection, callback) => {
+      callback(null);
+    },
+  },
+};
+
+const application = new jstp.Application(appName, interfaces);
+const serverConfig = { applications: [application] };
+const server = jstp.net.createServer(serverConfig);
+
+const client = {
+  session: null,
+  application: new jstp.Application(appName, interfaces),
+  reconnector: () => {},
+};
+
+server.listen(0, () => {
+  const port = server.address().port;
+  jstp.net.connect(
+    appName,
+    client,
+    port,
+    'localhost',
+    (error, connection) => {
+      test.assertNot(error, 'must connect to server');
+
+      const serverConnection = server.getClientsArray()[0];
+
+      connection.close();
+      serverConnection.callMethodWithResend('iface', 'method', [], (error) => {
+        test.assertNot(error, 'must not return an error');
+        connection.close();
+        server.close();
+        test.end();
+      });
+
+      const port = server.address().port;
+      client.session = connection.session;
+
+      jstp.net.reconnect(connection, port, 'localhost', (error, conn) => {
+        test.assertNot(error, 'must reconnect to server');
+        connection = conn;
+      });
+    }
+  );
+});

--- a/test/node/resendable-call-from-server.js
+++ b/test/node/resendable-call-from-server.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const test = require('tap');
+
+const cp = require('child_process');
+const path = require('path');
+
+const jstp = require('../..');
+
+let client = createClient();
+
+const appName = 'application';
+const interfaces = {
+  iface: {
+    method: (conn, callback) => {
+      callback(null);
+    },
+  },
+};
+
+const application = new jstp.Application(appName, interfaces);
+const serverConfig = { applications: [application] };
+const server = jstp.net.createServer(serverConfig);
+
+client.on('message', ([message, ...args]) => {
+  switch (message) {
+    case 'error':
+      test.fail(args[0].message);
+      break;
+    case 'connected':
+      client.kill('SIGKILL');
+      server
+        .getClientsArray()[0]
+        .callMethodWithResend('iface', 'method', [], (error) => {
+          test.assertNot(error, 'must not return an error');
+          server.close();
+          client.kill('SIGKILL');
+          test.end();
+        });
+      client = createClient();
+      client.send(['reconnect', server.address().port, args[0]]);
+      break;
+  }
+});
+
+server.listen(0, () => {
+  client.send(['connect', server.address().port]);
+});
+
+function createClient() {
+  return cp.fork(path.join(__dirname, '../utils/resendable-call/client.js'));
+}

--- a/test/utils/resendable-call/client.js
+++ b/test/utils/resendable-call/client.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const jstp = require('../../..');
+
+const appName = 'application';
+const interfaces = {
+  iface: {
+    method: (connection, callback) => {
+      callback(null);
+    },
+  },
+};
+
+const client = {
+  session: null,
+  application: new jstp.Application(appName, interfaces),
+};
+
+const connect = (port) => {
+  jstp.net.connect(
+    appName,
+    client,
+    port,
+    (error, conn, session) => {
+      if (error) {
+        process.send(['error', error]);
+      }
+      client.session = session;
+      process.send(['connected', session.toString()]);
+    }
+  );
+};
+
+const reconnect = (port, serializedSession) => {
+  client.session = jstp.Session.fromString(serializedSession);
+  jstp.net.connect(
+    appName,
+    client,
+    port,
+    (error) => {
+      if (error) {
+        process.send(['error', error]);
+      }
+    }
+  );
+};
+
+process.on('message', ([message, ...args]) => {
+  switch (message) {
+    case 'connect':
+      connect(...args);
+      break;
+    case 'reconnect':
+      reconnect(...args);
+      break;
+  }
+});

--- a/test/utils/resendable-call/server.js
+++ b/test/utils/resendable-call/server.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const jstp = require('../../..');
+
+const appName = 'application';
+const interfaces = {
+  iface: {
+    method: (connection, callback) => {
+      process.send(['callRecieved']);
+      callback(null);
+    },
+  },
+};
+
+const getSessionCallbacks = new Map();
+const sessionStorageProvider = {
+  isAsync: () => true,
+  get: (id, callback) => {
+    getSessionCallbacks.set(id, callback);
+    process.send(['getSession', id]);
+  },
+  set: (id, session) => {
+    process.send(['setSession', id, session.toString()]);
+  },
+};
+
+process.on('message', ([message, ...args]) => {
+  switch (message) {
+    case 'getSessionResponse': {
+      if (getSessionCallbacks.has(args[0])) {
+        const session = args[1] ? jstp.Session.fromString(args[1]) : undefined;
+        getSessionCallbacks.get(args[0])(session);
+      }
+      break;
+    }
+  }
+});
+
+const application = new jstp.Application(appName, interfaces);
+const serverConfig = { applications: [application], sessionStorageProvider };
+const server = jstp.net.createServer(serverConfig);
+
+server.on('connect', (connection) => {
+  sessionStorageProvider.set(connection.session.id, connection.session);
+});
+
+server.listen(0, () => {
+  process.send(['listening', server.address().port]);
+});


### PR DESCRIPTION
Callbacks passed to jstp method calls will now return an error when the
connection is being closed.
Since it is known, that callback messages are not being resent on connection
drop, a special method on Connection was added that resends call message on
connection to the server, and thus can be used for making a call to idempotent
methods on the server.

I would like to request some help with tests from @nechaido.
Also, there is a question about how we should deal with calls to remote methods done via RemoteProxy, I don't think that we should definitely resend all of the calls, but we should probably provide some possibility for the user to indicate that the call must be resent. Does anyone have any idea on how this should be done?