### PR TITLE
build: fail CI if native addon build fails

### DIFF
--- a/tools/build-native.js
+++ b/tools/build-native.js
@@ -44,7 +44,7 @@ fs.access('build', (error) => {
 });
 
 function handleBuildError(code) {
-  if (process.env.TRAVIS) {
+  if (process.env.CI) {
     process.exit(code);
   } else {
     console.warn('Could not build JSTP native extensions, ' +


### PR DESCRIPTION
This is an additional patch to that made in https://github.com/metarhia/jstp/pull/65 that enables failing for CI systems other than Travis.

Refs: https://github.com/metarhia/jstp/issues/63