### PR TITLE
lib: add missing callback call

### DIFF
--- a/lib/transport-common.js
+++ b/lib/transport-common.js
@@ -88,6 +88,10 @@ const newConnectAndInspectFn = (connFactory, transportClass) => {
       let errored = false;
       const len = interfaces.length;
       let count = 0;
+      if (len === 0) {
+        callback(null, connection, proxies);
+        return;
+      }
       interfaces.forEach((name) => {
         connection.inspectInterface(name, (error, proxy) => {
           if (!errored) {


### PR DESCRIPTION
Fix callback not being called in `connectAndInspect` family of functions when an empty array was provided in `interfaces` argument.