### PR TITLE
test: fix AppVeyor builds on Node.js 6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ branches:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install -g npm@latest
+  - npm install -g npm@5
   - npm install
 
 build: off


### PR DESCRIPTION
npm@6 seems to have problems running on Node.js 6.