### PR TITLE
connection: fix incorrect client-side message IDs

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -187,6 +187,7 @@ class Connection extends EventEmitter {
         if (!error) {
           this.session._restore(this, receivedCount);
           this.session._resendBufferedMessages();
+          this._nextMessageId = this.session.latestBufferedMessageId + 1;
         }
         if (callback) {
           callback(error);


### PR DESCRIPTION
Fix incorrect client-side message IDs, occurring after reconnection to
the existing session.