### PR TITLE
server: allow to return the real `authPolicy` error on authentication

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -166,7 +166,15 @@ class Server {
     this.authenticate(
       connection, application, strategy, credentials,
       (error, username) => {
-        if (error || !username) {
+        if (error) {
+          if (error instanceof errors.RemoteError) {
+            callback(error);
+          } else {
+            callback(error.message ? new errors.RemoteError(error.message) : errors.ERR_AUTH_FAILED)
+          }
+          return;
+        }
+        if (!username) {
           callback(errors.ERR_AUTH_FAILED);
           return;
         }


### PR DESCRIPTION
It would be very useful to return real authentication errors to the client, such as *Account locked*,  *Password expired*, etc.