### PR TITLE
server: enable returning errors from authPolicy

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -166,7 +166,17 @@ class Server {
     this.authenticate(
       connection, application, strategy, credentials,
       (error, username) => {
-        if (error || !username) {
+        if (error) {
+          if (error instanceof errors.RemoteError) {
+            callback(error);
+          } else {
+            callback(new errors.RemoteError(
+              errors.ERR_AUTH_FAILED, error.message
+            ));
+          }
+          return;
+        }
+        if (!username) {
           callback(errors.ERR_AUTH_FAILED);
           return;
         }


### PR DESCRIPTION
It would be very useful to return real authentication errors to the client, such as `Account locked`, `Password expired`, etc.