### PR TITLE
connection: fix reconnect throwing in some cases

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -73,27 +73,7 @@ class Connection extends EventEmitter {
     this._initTransport(transport);
 
     if (!this.client) return;
-    this.on('close', () => {
-      const reconnectFn = (...options) => {
-        let transport = options[0];
-        if (typeof transport !== 'string' || !transports[transport]) {
-          transport = this.client._connectionTransport;
-        }
-        const callback = common.extractCallback(options) || (() => {});
-        if (options.length === 0) {
-          options = this.client._connectionOptions;
-        }
-        this.emit('reconnectAttempt', transport, ...options);
-        transports[transport].reconnect(this, ...options, (err, ...rest) => {
-          this.emit('reconnect', err);
-          callback(err, ...rest);
-          if (err) {
-            this.client.reconnector(this, reconnectFn);
-          }
-        });
-      };
-      this.client.reconnector(this, reconnectFn);
-    });
+    this.once('close', () => this._reconnectHandler());
   }
 
   _initTransport(transport) {
@@ -106,6 +86,30 @@ class Connection extends EventEmitter {
     Object.keys(this._transportListeners).forEach((event) => {
       transport.on(event, this._transportListeners[event]);
     });
+  }
+
+  _reconnectHandler() {
+    const reconnectFn = (...options) => {
+      let transport = options[0];
+      if (typeof transport !== 'string' || !transports[transport]) {
+        transport = this.client._connectionTransport;
+      }
+      const callback = common.extractCallback(options) || (() => {});
+      if (options.length === 0) {
+        options = this.client._connectionOptions;
+      }
+      this.emit('reconnectAttempt', transport, ...options);
+      transports[transport].reconnect(this, ...options, (err, ...rest) => {
+        this.emit('reconnect', err);
+        callback(err, ...rest);
+        if (err) {
+          this.client.reconnector(this, reconnectFn);
+          return;
+        }
+        this.once('close', () => this._reconnectHandler());
+      });
+    };
+    this.client.reconnector(this, reconnectFn);
   }
 
   _removeTransport() {

--- a/test/node/reconnect-to-invalid-app.js
+++ b/test/node/reconnect-to-invalid-app.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const test = require('tap');
+
+const jstp = require('../..');
+
+const APP_NAME = 'APP_NAME';
+const INVALID_APP_NAME = 'INVALID_APP_NAME';
+
+const application = new jstp.Application(APP_NAME, {});
+const serverConfig = { applications: [application] };
+
+const DEFAULT_BACKOFF_TIME = 1000;
+const MAX_BACKOFF_TIME = 16000;
+const BACKOFF_OFFSET = 2000;
+let backoff = DEFAULT_BACKOFF_TIME;
+const reconnector = (connection, reconnectFn) => {
+  if (connection.closedIntentionally) return;
+  setTimeout(() => {
+    reconnectFn((error) => {
+      if (error) {
+        const newBackoff = backoff * 2;
+        backoff = (newBackoff < MAX_BACKOFF_TIME) ?
+          newBackoff : MAX_BACKOFF_TIME;
+        return;
+      }
+      backoff = DEFAULT_BACKOFF_TIME;
+    });
+  }, backoff);
+};
+
+test.test('reconnection to non-existent app must not throw', (test) => {
+  const server = jstp.net.createServer(serverConfig);
+  server.listen(0, () => {
+    const port = server.address().port;
+    jstp.net.connect(INVALID_APP_NAME, { reconnector }, port, 'localhost',
+      (error, conn) => {
+        test.assert(
+          error, 'connection to non-existent app must return an error'
+        );
+        setTimeout(() => {
+          conn.close();
+          server.close();
+          test.end();
+        }, MAX_BACKOFF_TIME - BACKOFF_OFFSET);
+      }
+    );
+  });
+});


### PR DESCRIPTION
Fix reconnection throwing when the error during the process also led to
the `close` event being emitted on the `connection` object.