### PR TITLE
test: increase timeout for heartbeat test to end 

### DIFF
--- a/test/node/connection-emit-actions.js
+++ b/test/node/connection-emit-actions.js
@@ -237,5 +237,5 @@ test.test('must emit heartbeat messages in development mode', (test) => {
     test.assert(received.serverPong, 'server must receive pong message');
     test.assert(received.clientPing, 'client must receive ping message');
     test.assert(received.clientPing, 'client must receive pong message');
-  }, 2 * HEARTBEAT_INTERVAL);
+  }, 3 * HEARTBEAT_INTERVAL);
 });


### PR DESCRIPTION
It appears that it may take more than `2 * HEARTBEAT_INTERVAL` to finish a full cycle of heartbeat messages. This commit increases timeout for the test to finish to `3 * HEARTBEAT_INTERVAL`.