### PR TITLE
test: update Travis config to use the current Node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - 6
   - 8
-  - 9
+  - 10
 
 os:
   - linux


### PR DESCRIPTION
Remove end-of-life Node.js 9 and add the current Node.js 10.