### PR TITLE
lib: fix resendable calls being sent twice

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -97,7 +97,9 @@ class Session extends Map {
       const callback = this.connection._callbacks.get(id);
       if (callback) {
         this.connection._callbacks.delete(id);
-        callback(errors.ERR_CALLBACK_LOST);
+        process.nextTick(() => {
+          callback(errors.ERR_CALLBACK_LOST);
+        });
       }
     }
     this.guaranteedDeliveredCount = receivedCount;


### PR DESCRIPTION
Due to the callbacks receiving error `ERR_CALLBACK_LOST` being called
synchronously during session restoration, calls with resending were
being resent twice: first time at the moment of such callback call
(leading to saving the call message into the session's buffer) and
second time immediately after the procedure of the session restoration
while resending all of the buffered messages (that by that moment
include unwanted call messages).