### PR TITLE
build: tell Babel parser the correct source type

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,5 +2,6 @@
   "presets": ["@babel/env"],
   "plugins": [
     "@babel/plugin-transform-runtime"
-  ]
+  ],
+  "sourceType": "script"
 }


### PR DESCRIPTION
Change the default `"sourceType": "module"` to the actual value of
`"sourceType": "script"`. This will prevent Babel from changing
top-level `this` to `undefined` (fwiw), and, more importantly, make
`plugin-transform-runtime` emit `require` statements instead of `import`
statements.

Fixes: https://github.com/metarhia/jstp/issues/377