### PR TITLE
v2.0.1 proposal

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,5 +2,6 @@
   "presets": ["@babel/env"],
   "plugins": [
     "@babel/plugin-transform-runtime"
-  ]
+  ],
+  "sourceType": "script"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # `@metarhia/jstp` changelog
 
+## Version 2.0.1 (2018-09-05, @belochub)
+
+This release fixes UMD browser build and updates links in README.
+
+All changes:
+
+ * **doc:** update package name in documentation
+   *(Mykola Bilochub)*
+   [#376](https://github.com/metarhia/jstp/pull/376)
+ * **build:** tell Babel parser the correct source type
+   *(Alexey Orlenko)*
+   [#378](https://github.com/metarhia/jstp/pull/378)
+
 ## Version 2.0.0 (2018-08-30, @belochub)
 
 Next major release of the package marks the addition of built-in reconnection

--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@
     src="https://coveralls.io/repos/github/metarhia/jstp/badge.svg?branch=master"
     alt="Coverage Status"
   /></a>
-  <a href="https://badge.fury.io/js/metarhia-jstp"><img
-    src="https://badge.fury.io/js/metarhia-jstp.svg"
+  <a href="https://badge.fury.io/js/%40metarhia%2Fjstp"><img
+    src="https://badge.fury.io/js/%40metarhia%2Fjstp.svg"
     alt="NPM Version"
   /></a>
-  <a href="https://www.npmjs.com/package/metarhia-jstp"><img
-    src="https://img.shields.io/npm/dm/metarhia-jstp.svg"
+  <a href="https://www.npmjs.com/package/@metarhia/jstp"><img
+    src="https://img.shields.io/npm/dm/@metarhia/jstp.svg"
     alt="NPM Downloads/Month"
   /></a>
-  <a href="https://www.npmjs.com/package/metarhia-jstp"><img
-    src="https://img.shields.io/npm/dt/metarhia-jstp.svg"
+  <a href="https://www.npmjs.com/package/@metarhia/jstp"><img
+    src="https://img.shields.io/npm/dt/@metarhia/jstp.svg"
     alt="NPM Downloads"
   /></a>
   <h1>JSTP / JavaScript Transfer Protocol</h1>
@@ -49,11 +49,11 @@ implementation bundled in!
 JSTP works in Node.js and web browsers:
 
 ```sh
-$ npm install --save metarhia-jstp
+$ npm install --save @metarhia/jstp
 ```
 
 Or, alternatively, there is
-[jstp.umd.js](https://unpkg.com/metarhia-jstp@latest/dist/jstp.umd.js)
+[jstp.umd.js](https://unpkg.com/@metarhia/jstp@latest/dist/jstp.umd.js)
 UMD bundle.
 
 We also have official client-side implementations for
@@ -68,7 +68,7 @@ Server:
 ```js
 'use strict';
 
-const jstp = require('metarhia-jstp');
+const jstp = require('@metarhia/jstp');
 
 // Application is the core high-level abstraction of the framework. An app
 // consists of a number of interfaces, and each interface has its methods.
@@ -95,7 +95,7 @@ Client:
 ```js
 'use strict';
 
-const jstp = require('metarhia-jstp');
+const jstp = require('@metarhia/jstp');
 
 // Create a TCP connection to server and connect to the `testApp` application.
 // Clients can have applications too for full-duplex RPC,

--- a/doc/README.md
+++ b/doc/README.md
@@ -18,11 +18,11 @@ and remote procedures.
 JSTP works in Node.js and web browsers:
 
 ```sh
-$ npm install --save metarhia-jstp
+$ npm install --save @metarhia/jstp
 ```
 
 Or, alternatively, there is
-[jstp.umd.js](https://unpkg.com/metarhia-jstp@latest/dist/jstp.umd.js)
+[jstp.umd.js](https://unpkg.com/@metarhia/jstp@latest/dist/jstp.umd.js)
 UMD bundle.
 
 We also have official client-side implementations for

--- a/doc/api/README.md
+++ b/doc/api/README.md
@@ -11,4 +11,4 @@
 * [Client](./client.md)
 
 This section provides complete and solid reference of the public API of
-`metarhia-jstp` package.
+`@metarhia/jstp` package.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@metarhia/jstp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@metarhia/jstp",
-  "version": "2.0.1",
+  "version": "2.0.2-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metarhia/jstp",
-  "version": "2.0.1",
+  "version": "2.0.2-pre",
   "author": "Timur Shemsedinov <timur.shemsedinov@gmail.com>",
   "description": "JavaScript Transfer Protocol for Impress Application Server",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metarhia/jstp",
-  "version": "2.0.1-pre",
+  "version": "2.0.1",
   "author": "Timur Shemsedinov <timur.shemsedinov@gmail.com>",
   "description": "JavaScript Transfer Protocol for Impress Application Server",
   "license": "MIT",


### PR DESCRIPTION
## Version 2.0.1 (2018-09-05, @belochub)

This release fixes UMD browser build and updates links in README.

All changes:

 * **doc:** update package name in documentation *(Mykola Bilochub)* [#376](https://github.com/metarhia/jstp/pull/376)
 * **build:** tell Babel parser the correct source type *(Alexey Orlenko)* [#378](https://github.com/metarhia/jstp/pull/378)