### PR TITLE
ws,server: fix server crash

### DIFF
--- a/lib/ws-internal.js
+++ b/lib/ws-internal.js
@@ -102,7 +102,10 @@ const initServer = function(options, httpServer) {
   httpServer.wsServer = new WebSocketServer(options);
 
   httpServer.wsServer.on('request', request => {
-    if (!httpServer.isOriginAllowed(request.origin)) {
+    if (
+      !httpServer.isOriginAllowed(request.origin) ||
+      !request.requestedProtocols.includes(constants.WEBSOCKET_PROTOCOL_NAME)
+    ) {
       request.reject();
       return;
     }

--- a/test/node/regress-gh-380.js
+++ b/test/node/regress-gh-380.js
@@ -1,0 +1,40 @@
+// Regression test for https://github.com/metarhia/jstp/pull/329
+
+'use strict';
+
+const test = require('tap');
+const { client: WebSocketClient } = require('websocket');
+
+const jstp = require('../..');
+
+const app = new jstp.Application('app', {});
+
+const makeTest = protocols => test => {
+  const server = jstp.ws.createServer([app]);
+
+  test.tearDown(() => {
+    server.close();
+  });
+
+  server.listen(0, () => {
+    const client = new WebSocketClient();
+    const url = `ws://localhost:${server.address().port}`;
+
+    client.once('connect', connection => {
+      connection.close();
+      test.fail('unreachable code: WS protocol negotiation is probably broken');
+      test.end();
+    });
+
+    client.once('connectFailed', () => {
+      test.end();
+    });
+
+    client.connect(url, protocols);
+  });
+};
+
+test.plan(2);
+
+test.test('must not crash with empty list of protocols', makeTest(null));
+test.test('must not crash with unsupported protocols', makeTest(['a', 'b']));


### PR DESCRIPTION
Fix server crash when `metarhia-jstp` is not in the list of the requested protocols.