### PR TITLE
ws: use transport similar to the socket ones

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -143,6 +143,48 @@ class ExpiringMap extends Map {
   }
 }
 
+const utf16singleUnit = 1 << 16;
+
+// https://tools.ietf.org/html/rfc3629#section-3
+const utf8bytesLastCodePoints = {
+  1: 0x007F,
+  2: 0x07FF,
+  3: 0xFFFF,
+};
+
+const utf8split = (str, maxByteCount) => {
+  let utf8length = 0;
+  for (let i = 0; i < str.length;) {
+    const codePoint = str.codePointAt(i);
+
+    // Calculate code point size in bytes when encoded with UTF-8:
+    let utf8codePointSize = 4;
+    for (let byteCount = 1; byteCount <= 3; byteCount++) {
+      if (codePoint <= utf8bytesLastCodePoints[byteCount]) {
+        utf8codePointSize = byteCount;
+        break;
+      }
+    }
+
+    // Calculate code point size in bytes when encoded with UTF-16:
+    const utf16codePointSize = (codePoint >= utf16singleUnit) ? 2 : 1;
+    if (utf8codePointSize > maxByteCount) {
+      return [str.slice(0, i), str.slice(i), utf8length];
+    } else if (utf8codePointSize === maxByteCount) {
+      const splitPoint = i + utf16codePointSize;
+      return [
+        str.slice(0, splitPoint),
+        str.slice(splitPoint),
+        utf8length + utf8codePointSize,
+      ];
+    }
+    maxByteCount -= utf8codePointSize;
+    utf8length += utf8codePointSize;
+    i += utf16codePointSize;
+  }
+  return [str, '', utf8length];
+};
+
 module.exports = {
   forwardEvent,
   forwardMultipleEvents,
@@ -153,4 +195,5 @@ module.exports = {
   rsplit,
   cryptoRandom,
   ExpiringMap,
+  utf8split,
 };

--- a/lib/common.js
+++ b/lib/common.js
@@ -143,7 +143,7 @@ class ExpiringMap extends Map {
   }
 }
 
-const utf16singleUnit = 1 << 16;
+const utf16singleUnit = (1 << 16) - 1;
 
 // https://tools.ietf.org/html/rfc3629#section-3
 const utf8bytesLastCodePoints = {
@@ -167,7 +167,7 @@ const utf8split = (str, maxByteCount) => {
     }
 
     // Calculate code point size in bytes when encoded with UTF-16:
-    const utf16codePointSize = (codePoint >= utf16singleUnit) ? 2 : 1;
+    const utf16codePointSize = (codePoint > utf16singleUnit) ? 2 : 1;
     if (utf8codePointSize > maxByteCount) {
       return [str.slice(0, i), str.slice(i), utf8length];
     } else if (utf8codePointSize === maxByteCount) {

--- a/lib/internal-constants.js
+++ b/lib/internal-constants.js
@@ -2,4 +2,6 @@
 
 module.exports = {
   WEBSOCKET_PROTOCOL_NAME: 'metarhia-jstp',
+  MAX_MESSAGE_SIZE: 8 * 1024 * 1024,
+  SEPARATOR: '\0',
 };

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -6,9 +6,9 @@ const mdsf = require('mdsf');
 
 const transportCommon = require('./transport-common');
 const common = require('./common');
+const { MAX_MESSAGE_SIZE } = require('./internal-constants');
 
 const SEPARATOR = Buffer.alloc(1);
-const MAX_MESSAGE_SIZE = 8 * 1024 * 1024;
 
 // JSTP transport for POSIX socket
 //

--- a/lib/ws-browser.js
+++ b/lib/ws-browser.js
@@ -5,8 +5,12 @@ const EventEmitter = require('events').EventEmitter;
 
 const mdsf = require('mdsf');
 
+const { utf8split } = require('./common');
 const constants = require('./internal-constants');
 const transportCommon = require('./transport-common');
+
+const SEND_INTERVAL = 50;
+const BUFFER_SIZE_LIMIT = 64000;
 
 // W3C WebSocket transport for JSTP.
 //   socket - WebSocket instance
@@ -17,16 +21,26 @@ class Transport extends EventEmitter {
     super();
 
     this.socket = socket;
+    this._receiveBuffer = '';
+    this._sendBuffer = [];
+    this._closed = false;
 
     this.socket.onmessage = message => {
       this._onMessage(message);
     };
 
-
     ['close', 'error'].forEach(event => {
       this.socket.addEventListener(event, (...args) => {
         this.emit(event, ...args);
       });
+    });
+
+    this._sendInterval = setInterval(() => {
+      this._sendBufferedMessages();
+    }, SEND_INTERVAL);
+
+    this.once('close', () => {
+      clearInterval(this._sendInterval);
     });
   }
 
@@ -36,15 +50,53 @@ class Transport extends EventEmitter {
     return this.socket;
   }
 
+  _sendBufferedMessages() {
+    let bufferedAmount = this.socket.bufferedAmount;
+    let toSend = '';
+    while (this._sendBuffer.length !== 0) {
+      const message = this._sendBuffer[0];
+      const maxChunkLength = BUFFER_SIZE_LIMIT - bufferedAmount;
+      if (maxChunkLength < 0) {
+        this.socket.close();
+        throw new Error('WebSocket buffer is overflown');
+      }
+      if (maxChunkLength === 0) {
+        break;
+      }
+      const [
+        partToSend,
+        remainingPart,
+        toSendLength,
+      ] = utf8split(message, maxChunkLength);
+      toSend += partToSend;
+      bufferedAmount += toSendLength;
+      if (remainingPart !== '') {
+        this._sendBuffer[0] = remainingPart;
+        break;
+      }
+      this._sendBuffer.shift();
+    }
+    if (toSend !== '') {
+      this.socket.send(toSend);
+    }
+    if (this._closed && this._sendBuffer.length === 0) {
+      this.socket.close();
+    }
+  }
+
   // Send data over the connection.
   //   data - Buffer or string
   //
   send(data) {
+    if (this._closed) {
+      throw new Error('WebSocket: send after end');
+    }
+
     if (Buffer.isBuffer(data)) {
       data = data.toString();
     }
 
-    this.socket.send(data);
+    this._sendBuffer.push(data + constants.SEPARATOR);
   }
 
   // End the connection optionally sending the last chunk of data.
@@ -55,7 +107,7 @@ class Transport extends EventEmitter {
       this.send(data);
     }
 
-    this.socket.close();
+    this._closed = true;
   }
 
   // WebSocket message handler.
@@ -68,15 +120,24 @@ class Transport extends EventEmitter {
         new Buffer(message.data).toString()
     );
 
-    let parsed;
+    const messages = [];
+    this._receiveBuffer += data;
+
     try {
-      parsed = mdsf.parse(data);
+      this._receiveBuffer =
+        mdsf.parseJSTPMessages(this._receiveBuffer, messages);
     } catch (error) {
       this.emit('error', error);
       return;
     }
 
-    this.emit('message', parsed);
+    for (let i = 0; i < messages.length; i++) {
+      this.emit('message', messages[i]);
+    }
+
+    if (this._receiveBuffer.length > constants.MAX_MESSAGE_SIZE) {
+      this.emit('error', new Error('Maximal message size exceeded'));
+    }
   }
 }
 

--- a/lib/ws-internal.js
+++ b/lib/ws-internal.js
@@ -19,6 +19,7 @@ class Transport extends EventEmitter {
     super();
 
     this.connection = connection;
+    this._buffer = '';
 
     this.connection.on('error', () => {
       this.connection.drop();
@@ -45,7 +46,7 @@ class Transport extends EventEmitter {
       data = data.toString();
     }
 
-    this.connection.sendUTF(data);
+    this.connection.sendUTF(data + constants.SEPARATOR);
   }
 
   // End the connection optionally sending the last chunk of data.
@@ -65,15 +66,23 @@ class Transport extends EventEmitter {
       message.type === 'utf8' ? message.utf8Data : message.binaryData.toString()
     );
 
-    let parsed;
+    const messages = [];
+    this._buffer += data;
+
     try {
-      parsed = mdsf.parse(data);
+      this._buffer = mdsf.parseJSTPMessages(this._buffer, messages);
     } catch (error) {
       this.emit('error', error);
       return;
     }
 
-    this.emit('message', parsed);
+    for (let i = 0; i < messages.length; i++) {
+      this.emit('message', messages[i]);
+    }
+
+    if (this._buffer.length > constants.MAX_MESSAGE_SIZE) {
+      this.emit('error', new Error('Maximal message size exceeded'));
+    }
   }
 }
 

--- a/test/node/common-utf8split.js
+++ b/test/node/common-utf8split.js
@@ -1,0 +1,204 @@
+'use strict';
+
+const test = require('tap').test;
+
+const { utf8split } = require('../../lib/common');
+
+const runTestCases = (test, string, testCases) => {
+  testCases.forEach(testCase => {
+    const result = utf8split(string, testCase.maxByteCount);
+    test.strictSame(result, testCase.result);
+  });
+};
+
+test(
+  'must correctly split strings with code points using single UTF-8 code unit',
+  test => {
+    const string = 'test string';
+    const testCases = [
+      {
+        maxByteCount: 1,
+        result: ['t', 'est string', 1],
+      },
+      {
+        maxByteCount: 5,
+        result: ['test ', 'string', 5],
+      },
+      {
+        maxByteCount: 11,
+        result: ['test string', '', 11],
+      },
+      {
+        maxByteCount: 15,
+        result: ['test string', '', 11],
+      },
+    ];
+    runTestCases(test, string, testCases);
+    test.end();
+  }
+);
+
+test(
+  'must correctly split strings with code points using two UTF-8 code units',
+  test => {
+    const string = 'тестоваястрока';
+    const testCases = [
+      {
+        maxByteCount: 1,
+        result: ['', 'тестоваястрока', 0],
+      },
+      {
+        maxByteCount: 2,
+        result: ['т', 'естоваястрока', 2],
+      },
+      {
+        maxByteCount: 17,
+        result: ['тестовая', 'строка', 16],
+      },
+      {
+        maxByteCount: 28,
+        result: ['тестоваястрока', '', 28],
+      },
+      {
+        maxByteCount: 31,
+        result: ['тестоваястрока', '', 28],
+      },
+    ];
+    runTestCases(test, string, testCases);
+    test.end();
+  }
+);
+
+test(
+  'must correctly split strings with code points using three UTF-8 code units',
+  test => {
+    const string = '测试字符串';
+    const testCases = [
+      {
+        maxByteCount: 1,
+        result: ['', '测试字符串', 0],
+      },
+      {
+        maxByteCount: 2,
+        result: ['', '测试字符串', 0],
+      },
+      {
+        maxByteCount: 3,
+        result: ['测', '试字符串', 3],
+      },
+      {
+        maxByteCount: 8,
+        result: ['测试', '字符串', 6],
+      },
+      {
+        maxByteCount: 15,
+        result: ['测试字符串', '', 15],
+      },
+      {
+        maxByteCount: 20,
+        result: ['测试字符串', '', 15],
+      },
+    ];
+    runTestCases(test, string, testCases);
+    test.end();
+  }
+);
+
+test(
+  'must correctly split strings with code points using four UTF-8 code units',
+  test => {
+    const string = '💓💕💖💗💝';
+    const testCases = [
+      {
+        maxByteCount: 1,
+        result: ['', '💓💕💖💗💝', 0],
+      },
+      {
+        maxByteCount: 2,
+        result: ['', '💓💕💖💗💝', 0],
+      },
+      {
+        maxByteCount: 3,
+        result: ['', '💓💕💖💗💝', 0],
+      },
+      {
+        maxByteCount: 4,
+        result: ['💓', '💕💖💗💝', 4],
+      },
+      {
+        maxByteCount: 12,
+        result: ['💓💕💖', '💗💝', 12],
+      },
+      {
+        maxByteCount: 14,
+        result: ['💓💕💖', '💗💝', 12],
+      },
+      {
+        maxByteCount: 20,
+        result: ['💓💕💖💗💝', '', 20],
+      },
+      {
+        maxByteCount: 25,
+        result: ['💓💕💖💗💝', '', 20],
+      },
+    ];
+    runTestCases(test, string, testCases);
+    test.end();
+  }
+);
+
+test(
+  'must correctly split strings with code points using different counts of ' +
+  'UTF-8 code units',
+  test => {
+    const string = 'т测t💓';
+    const testCases = [
+      {
+        maxByteCount: 1,
+        result: ['', 'т测t💓', 0],
+      },
+      {
+        maxByteCount: 2,
+        result: ['т', '测t💓', 2],
+      },
+      {
+        maxByteCount: 3,
+        result: ['т', '测t💓', 2],
+      },
+      {
+        maxByteCount: 4,
+        result: ['т', '测t💓', 2],
+      },
+      {
+        maxByteCount: 5,
+        result: ['т测', 't💓', 5],
+      },
+      {
+        maxByteCount: 6,
+        result: ['т测t', '💓', 6],
+      },
+      {
+        maxByteCount: 7,
+        result: ['т测t', '💓', 6],
+      },
+      {
+        maxByteCount: 8,
+        result: ['т测t', '💓', 6],
+      },
+      {
+        maxByteCount: 9,
+        result: ['т测t', '💓', 6],
+      },
+      {
+        maxByteCount: 10,
+        result: ['т测t💓', '', 10],
+      },
+      {
+        maxByteCount: 11,
+        result: ['т测t💓', '', 10],
+      },
+    ];
+    runTestCases(test, string, testCases);
+    test.end();
+  }
+);


### PR DESCRIPTION
Previously every JSTP message was sent in a separate WebSocket frame.
This commit changes WebSocket usage so that JSTP message is not limited
to a single WebSocket frame. This is accomplished by making the
WebSocket JSTP transport behave in a way similar to the other available
transports, which is after every message, there is a separator. This
change leads to a WebSocket frame being able to hold multiple JSTP
messages at once or a part of a big JSTP message, that cannot be
transmitted in a single frame. This is a breaking change since it
completely changes the way the messages are transmitted over WebSockets.