### PR TITLE
ws,server: change max frame and message size

### DIFF
--- a/lib/internal-constants.js
+++ b/lib/internal-constants.js
@@ -2,4 +2,5 @@
 
 module.exports = {
   WEBSOCKET_PROTOCOL_NAME: 'metarhia-jstp',
+  MAX_MESSAGE_SIZE: 8 * 1024 * 1024,
 };

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -6,9 +6,9 @@ const mdsf = require('mdsf');
 
 const transportCommon = require('./transport-common');
 const common = require('./common');
+const { MAX_MESSAGE_SIZE } = require('./internal-constants');
 
 const SEPARATOR = Buffer.alloc(1);
-const MAX_MESSAGE_SIZE = 8 * 1024 * 1024;
 
 // JSTP transport for POSIX socket
 //

--- a/lib/ws-internal.js
+++ b/lib/ws-internal.js
@@ -87,6 +87,8 @@ const initServer = function(options, httpServer) {
   options = Object.assign({}, options, {
     httpServer,
     autoAcceptConnections: false,
+    maxReceivedFrameSize: constants.MAX_MESSAGE_SIZE,
+    maxReceivedMessageSize: constants.MAX_MESSAGE_SIZE,
   });
 
   httpServer.isOriginAllowed =


### PR DESCRIPTION
Change the maximally allowed frame and message size for WS server to
a maximal size of JSTP message allowed (8 MiB).

This fixes the same issue as https://github.com/metarhia/jstp/pull/381 with the least amount of changes, thus I'd prefer to land this PR instead of https://github.com/metarhia/jstp/pull/381.