### PR TITLE
v2.1.0 proposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # `@metarhia/jstp` changelog
 
+## Version 2.1.0 (2018-10-02, @belochub)
+
+This release fixes and improves WebSocket transport.
+
+All changes:
+
+ * **ws,server:** fix server crash
+   *(Mykola Bilochub)*
+   [#380](https://github.com/metarhia/jstp/pull/380)
+ * **test:** add regression test for GH-380
+   *(Alexey Orlenko)*
+   [#380](https://github.com/metarhia/jstp/pull/380)
+ * **deps,lint:** update eslint-config-metarhia
+   *(Mykola Bilochub)*
+   [#382](https://github.com/metarhia/jstp/pull/382)
+ * **ws,server:** change max frame and message size
+   *(Mykola Bilochub)*
+   [#383](https://github.com/metarhia/jstp/pull/383)
+   **\[semver-minor\]**
+
 ## Version 2.0.1 (2018-09-05, @belochub)
 
 This release fixes UMD browser build and updates links in README.

--- a/benchmark/statistics.js
+++ b/benchmark/statistics.js
@@ -2,8 +2,7 @@
 
 const mean = sample => {
   const len = sample.length;
-  if (len === 0)
-    return;
+  if (len === 0) return 0;
   let sum = 0;
   for (let i = 0; i < len; i++) {
     sum += sample[i];
@@ -13,10 +12,7 @@ const mean = sample => {
 
 const stdev = (sample, meanValue) => {
   const len = sample.length;
-  if (len === 0)
-    return;
-  if (len === 1)
-    return 0;
+  if (len === 0 || len === 1) return 0;
   let sum = 0;
   for (let i = 0; i < len; i++) {
     sum += Math.pow(sample[i] - meanValue, 2);
@@ -53,12 +49,6 @@ const combineStdev = (samples, mean, count) => {
 };
 
 const combineSamples = samples => {
-  const len = samples.length;
-  if (len === 0)
-    return;
-  if (len === 1) {
-    return samples[0];
-  }
   const count = combineCount(samples);
   const mean  = combineMean(samples, count);
   const stdev = combineStdev(samples, mean, count);

--- a/lib/internal-constants.js
+++ b/lib/internal-constants.js
@@ -2,4 +2,5 @@
 
 module.exports = {
   WEBSOCKET_PROTOCOL_NAME: 'metarhia-jstp',
+  MAX_MESSAGE_SIZE: 8 * 1024 * 1024,
 };

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -6,9 +6,9 @@ const mdsf = require('mdsf');
 
 const transportCommon = require('./transport-common');
 const common = require('./common');
+const { MAX_MESSAGE_SIZE } = require('./internal-constants');
 
 const SEPARATOR = Buffer.alloc(1);
-const MAX_MESSAGE_SIZE = 8 * 1024 * 1024;
 
 // JSTP transport for POSIX socket
 //

--- a/lib/ws-internal.js
+++ b/lib/ws-internal.js
@@ -102,7 +102,10 @@ const initServer = function(options, httpServer) {
   httpServer.wsServer = new WebSocketServer(options);
 
   httpServer.wsServer.on('request', request => {
-    if (!httpServer.isOriginAllowed(request.origin)) {
+    if (
+      !httpServer.isOriginAllowed(request.origin) ||
+      !request.requestedProtocols.includes(constants.WEBSOCKET_PROTOCOL_NAME)
+    ) {
       request.reject();
       return;
     }

--- a/lib/ws-internal.js
+++ b/lib/ws-internal.js
@@ -87,6 +87,8 @@ const initServer = function(options, httpServer) {
   options = Object.assign({}, options, {
     httpServer,
     autoAcceptConnections: false,
+    maxReceivedFrameSize: constants.MAX_MESSAGE_SIZE,
+    maxReceivedMessageSize: constants.MAX_MESSAGE_SIZE,
   });
 
   httpServer.isOriginAllowed =

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@metarhia/jstp",
-  "version": "2.1.0",
+  "version": "2.1.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@metarhia/jstp",
-  "version": "2.0.2-pre",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2972,9 +2972,9 @@
       }
     },
     "eslint-config-metarhia": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-metarhia/-/eslint-config-metarhia-4.0.0.tgz",
-      "integrity": "sha512-AxygbQxoAT3y9QCCulBu82suUjoUUR1dIy/J+ksKEOVBIUX8hrYE5OLTnGD2zkk+lCgJ6qS1qNvGQxwB8Jniew==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-metarhia/-/eslint-config-metarhia-5.0.0.tgz",
+      "integrity": "sha512-m5duvNQiqeco7uQZYyTkZPUW6kNzsPexTW4Roo0GE+hTayJLEQlhKKLDZlbqhKEjg1nobSwUTN9NV6x+p3x6WQ==",
       "dev": true
     },
     "eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metarhia/jstp",
-  "version": "2.1.0",
+  "version": "2.1.1-pre",
   "author": "Timur Shemsedinov <timur.shemsedinov@gmail.com>",
   "description": "JavaScript Transfer Protocol for Impress Application Server",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/runtime": "^7.0.0",
     "babel-loader": "^8.0.0",
     "eslint": "^5.2.0",
-    "eslint-config-metarhia": "^4.0.0",
+    "eslint-config-metarhia": "^5.0.0",
     "eslint-plugin-import": "^2.11.0",
     "remark-cli": "^5.0.0",
     "remark-preset-lint-metarhia": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metarhia/jstp",
-  "version": "2.0.2-pre",
+  "version": "2.1.0",
   "author": "Timur Shemsedinov <timur.shemsedinov@gmail.com>",
   "description": "JavaScript Transfer Protocol for Impress Application Server",
   "license": "MIT",

--- a/test/fixtures/application.js
+++ b/test/fixtures/application.js
@@ -46,7 +46,8 @@ const authCallback = (
   connection, application, strategy, credentials, callback
 ) => {
   if (application.name !== name) {
-    return callback(new jstp.RemoteError(jstp.ERR_APP_NOT_FOUND));
+    callback(new jstp.RemoteError(jstp.ERR_APP_NOT_FOUND));
+    return;
   }
 
   let username = null;

--- a/test/node/regress-gh-380.js
+++ b/test/node/regress-gh-380.js
@@ -1,0 +1,40 @@
+// Regression test for https://github.com/metarhia/jstp/pull/329
+
+'use strict';
+
+const test = require('tap');
+const { client: WebSocketClient } = require('websocket');
+
+const jstp = require('../..');
+
+const app = new jstp.Application('app', {});
+
+const makeTest = protocols => test => {
+  const server = jstp.ws.createServer([app]);
+
+  test.tearDown(() => {
+    server.close();
+  });
+
+  server.listen(0, () => {
+    const client = new WebSocketClient();
+    const url = `ws://localhost:${server.address().port}`;
+
+    client.once('connect', connection => {
+      connection.close();
+      test.fail('unreachable code: WS protocol negotiation is probably broken');
+      test.end();
+    });
+
+    client.once('connectFailed', () => {
+      test.end();
+    });
+
+    client.connect(url, protocols);
+  });
+};
+
+test.plan(2);
+
+test.test('must not crash with empty list of protocols', makeTest(null));
+test.test('must not crash with unsupported protocols', makeTest(['a', 'b']));

--- a/tools/prepare-release.js
+++ b/tools/prepare-release.js
@@ -142,27 +142,33 @@ function httpsGetJson(options) {
   return new Promise((resolve, reject) => {
     https.get(options, res => {
       getStreamData(res, (err, json) => {
-        if (err) return reject(err);
+        if (err) {
+          reject(err);
+          return;
+        }
 
         if (res.statusCode !== 200) {
           const url = `https://${options.host}${options.path}`;
           const message = `Request to ${url} failed with status code ` +
                           res.statusCode;
-          return reject(`${message}\n${json}`);
+          reject(new Error(`${message}\n${json}`));
+          return;
         }
 
         const contentType = res.headers['content-type'];
         if (!contentType.startsWith('application/json')) {
           const error = new Error(`Invalid Content-Type: ${contentType}`);
           res.resume();
-          return reject(error);
+          reject(error);
+          return;
         }
 
         let object = null;
         try {
           object = JSON.parse(json);
         } catch (err) {
-          return reject(err);
+          reject(err);
+          return;
         }
         resolve(object);
       });


### PR DESCRIPTION
## Version 2.1.0 (2018-10-02, @belochub)

This release fixes and improves WebSocket transport.

All changes:

 * **ws,server:** fix server crash *(Mykola Bilochub)* [#380](https://github.com/metarhia/jstp/pull/380)
 * **test:** add regression test for GH-380 *(Alexey Orlenko)* [#380](https://github.com/metarhia/jstp/pull/380)
 * **deps,lint:** update eslint-config-metarhia *(Mykola Bilochub)* [#382](https://github.com/metarhia/jstp/pull/382)
 * **ws,server:** change max frame and message size *(Mykola Bilochub)* [#383](https://github.com/metarhia/jstp/pull/383) **\[semver-minor\]**
