### PR TITLE
conn: make reconnection consistent

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -56,6 +56,7 @@ class Connection extends EventEmitter {
 
     this._heartbeatTimer = null;
 
+    this.hasConnected = false;
     this.closedIntentionally = false;
 
     // Defined in constructor to be used as default callback in callMethod
@@ -73,7 +74,11 @@ class Connection extends EventEmitter {
     this._initTransport(transport);
 
     if (!this.client) return;
-    this.once('close', () => this._reconnectHandler());
+    this.once('close', () => {
+      if (this.hasConnected) {
+        this._reconnectHandler();
+      }
+    });
   }
 
   _initTransport(transport) {
@@ -655,6 +660,7 @@ class Connection extends EventEmitter {
 
       this.handshakeDone = true;
       this.application = this.client.application;
+      this.hasConnected = true;
 
       callback(null, message.ok);
     } else if (message.error) {

--- a/test/node/reconnection-on-unsuccessful-connection.js
+++ b/test/node/reconnection-on-unsuccessful-connection.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const test = require('tap');
+
+const jstp = require('../..');
+
+const TIMEOUT = 5000;
+
+const APP_NAME = 'APP_NAME';
+const INVALID_APP_NAME = 'INVALID_APP_NAME';
+
+const application = new jstp.Application(APP_NAME, {});
+const serverConfig = { applications: [application] };
+
+test.test('must not reconnect after failed connection', test => {
+  let reconnectionAttempts = 0;
+  const reconnector = () => {
+    reconnectionAttempts++;
+  };
+  jstp.net.connect(
+    APP_NAME, { reconnector }, 0, '__invalid_host__', error => {
+      test.assert(error, 'must fail handshake');
+    }
+  );
+  setTimeout(() => {
+    test.strictSame(reconnectionAttempts, 0);
+    test.end();
+  }, TIMEOUT);
+});
+
+test.test('must not reconnect after failed handshake', test => {
+  let connectionAttempts = 0;
+  const server = jstp.net.createServer(serverConfig);
+  server.on('connection', () => {
+    connectionAttempts++;
+  });
+  server.listen(0, () => {
+    const port = server.address().port;
+    jstp.net.connect(
+      INVALID_APP_NAME, null, port, 'localhost', error => {
+        test.strictSame(
+          error.code, jstp.ERR_APP_NOT_FOUND, 'must fail handshake'
+        );
+      }
+    );
+  });
+  setTimeout(() => {
+    test.strictSame(connectionAttempts, 1);
+    server.close();
+    test.end();
+  }, TIMEOUT);
+});


### PR DESCRIPTION
Completely disable reconnection before establishing a JSTP connection
successfully for at least one time.

Before, reconnection retries were implicitly happening before
successfully establishing JSTP connection in a case when transport
(tcp/tls/ws) connection was successfully established, but JSTP handshake
failed. At the same time, reconnection was disabled whenever it was not
possible to establish a transport connection to the server.