### PR TITLE
conn: return error when handshake is not received

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -220,12 +220,7 @@ class Connection extends EventEmitter {
     }
 
     if (version && !semver.validRange(version)) {
-      const error = new Error('Invalid semver version range');
-      if (callback) {
-        callback(error);
-      } else {
-        this.emit('error', error);
-      }
+      callback(new Error('Invalid semver version range'));
       return;
     }
 
@@ -257,28 +252,30 @@ class Connection extends EventEmitter {
 
     const messageId = message.handshake[0];
     let cb;
+    const closeListener = () => {
+      cb(new errors.RemoteError(errors.ERR_NO_HANDSHAKE_RESPONSE));
+    };
+    this.once('close', closeListener);
     if (isNewSession) {
       cb = (error, sessionId) => {
+        this.removeListener('close', closeListener);
         if (!error) {
           if (login && password) {
             this.username = login;
           }
           this.session = new Session(this, this.username, sessionId);
         }
-        if (callback) {
-          callback(error, this.session);
-        }
+        callback(error, this.session);
       };
     } else {
       cb = (error, receivedCount) => {
+        this.removeListener('close', closeListener);
         if (!error) {
           this.session._restore(this, receivedCount);
           this.session._resendBufferedMessages();
           this._nextMessageId = this.session.latestBufferedMessageId + 1;
         }
-        if (callback) {
-          callback(error);
-        }
+        callback(error);
       };
     }
     this._callbacks.set(messageId, cb);

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -2,6 +2,7 @@
 
 // Implementation defined errors
 const ERR_CALLBACK_LOST = -1;
+const ERR_NO_HANDSHAKE_RESPONSE = -2;
 
 // Standard protocol errors
 const ERR_APP_NOT_FOUND = 10;
@@ -16,6 +17,7 @@ const ERR_INVALID_SIGNATURE = 17;
 // Default messages for predefined error codes
 const defaultMessages = {
   [ERR_CALLBACK_LOST]:          'Connection closed before receiving callback',
+  [ERR_NO_HANDSHAKE_RESPONSE]:  'Connection closed before receiving handshake',
   [ERR_APP_NOT_FOUND]:          'Application not found',
   [ERR_AUTH_FAILED]:            'Authentication failed',
   [ERR_INTERFACE_NOT_FOUND]:    'Interface not found',
@@ -99,6 +101,7 @@ class RemoteError extends Error {
 
 module.exports = {
   ERR_CALLBACK_LOST,
+  ERR_NO_HANDSHAKE_RESPONSE,
   ERR_APP_NOT_FOUND,
   ERR_AUTH_FAILED,
   ERR_INTERFACE_NOT_FOUND,

--- a/test/node/handshake-error-on-connection-close.js
+++ b/test/node/handshake-error-on-connection-close.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const net = require('net');
+
+const test = require('tap');
+
+const jstp = require('../..');
+
+test.test(
+  'handshake must return error when connection is closed before handshake',
+  test => {
+    const server = net.createServer(socket => {
+      socket.destroy();
+    });
+    server.listen(0, () => {
+      const port = server.address().port;
+      jstp.net.connect(
+        'APP_NAME', null, port, 'localhost', error => {
+          if (error instanceof jstp.RemoteError) {
+            test.strictSame(error.code, jstp.ERR_NO_HANDSHAKE_RESPONSE);
+          } else {
+            test.assert(error);
+          }
+          server.close();
+          test.end();
+        }
+      );
+    });
+  }
+);


### PR DESCRIPTION
Return error from `Connection#handshake()` method when connection is
closed before handshake response is received. Also, make this method's
`callback` argument mandatory.

This depends on https://github.com/metarhia/jstp/pull/386 and https://github.com/metarhia/jstp/pull/389