### PR TITLE
 lib: fix unhandled error events on connection

### DIFF
--- a/lib/transport-common.js
+++ b/lib/transport-common.js
@@ -96,9 +96,17 @@ const newConnectFn = (
     client._connectionOptions = options;
     client._connectionTransport = transportName;
     const connection = new Connection(transport, null, client);
+    let callbackCalled = false;
+    const errorListener = error => {
+      callback(error);
+      callbackCalled = true;
+    };
+    connection.once('error', errorListener);
     client.connectPolicy(
       app, connection, client.session,
       (error, connection, session) => {
+        if (callbackCalled) return;
+        connection.removeListener('error', errorListener);
         connection._serverApp = app;
         if (error) {
           callback(error, connection);

--- a/test/node/unhandled-error-event-on-connect.js
+++ b/test/node/unhandled-error-event-on-connect.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const test = require('tap');
+
+const jstp = require('../..');
+
+const APP_NAME = 'APP_NAME';
+
+const application = new jstp.Application(APP_NAME, {});
+const serverConfig = { applications: [application] };
+
+test.test('transport.connect must return connection error', test => {
+  const server = jstp.net.createServer(serverConfig);
+  server.listen(0, () => {
+    const port = server.address().port;
+    jstp.tls.connect(
+      APP_NAME, null, port, 'localhost', error => {
+        test.assert(error, 'connect must fail');
+        server.close();
+        test.end();
+      }
+    );
+  });
+});


### PR DESCRIPTION
Fix error events on `Connection` object being unhandled inside the
`Transport#connect()` method, thus leading to the errors being thrown
instead of reported to the callback.

This depends on https://github.com/metarhia/jstp/pull/386