### PR TITLE
ws,server: avoid forwarding 'clientError' event

### DIFF
--- a/lib/ws-internal.js
+++ b/lib/ws-internal.js
@@ -94,8 +94,6 @@ const initServer = function(options, httpServer) {
   httpServer.isOriginAllowed =
     options.originCheckStrategy || allowAllOriginCheckStrategy;
 
-  common.forwardEvent(httpServer, httpServer, 'clientError', 'error');
-
   httpServer.on('request', (request, response) => {
     response.writeHead(400);
     response.end();


### PR DESCRIPTION
Avoid forwarding 'clientError' event on the WebSocket server as an
'error' event. That behavior was causing server crashes and could
possibly lead to hanging HTTP connections.