### PR TITLE
lib: change the default reconnector behavior

### DIFF
--- a/lib/transport-common.js
+++ b/lib/transport-common.js
@@ -14,8 +14,8 @@ function createDefaultReconnector() {
   const randomMsecGen =
     () => Math.floor((RANDOM_OFFSET_MAX + 1) * common.cryptoRandom());
   return (connection, reconnectFn) => {
-    if (connection.closedIntentionally) return;
     setTimeout(() => {
+      if (connection.closedIntentionally) return;
       reconnectFn(error => {
         if (error) {
           const newBackoff = backoff * 2;

--- a/test/node/default-reconnector-backoff.js
+++ b/test/node/default-reconnector-backoff.js
@@ -16,7 +16,7 @@ const server =
   cp.fork(path.join(__dirname, '../utils/reconnector/server-for-backoff.js'));
 
 server.on('message', ([type, port]) => {
-  test.plan(EXPECTED_ATTEMPTS_TO_RECONNECT + 1);
+  test.plan(EXPECTED_ATTEMPTS_TO_RECONNECT);
 
   if (type !== 'listening') {
     test.fail('must not receive unknown messages');


### PR DESCRIPTION
Avoid trying to reconnect for additional one time after the connection is intentionally closed in some cases.