### PR TITLE
lib: remove unsupported Web Crypto API console warning

### DIFF
--- a/lib/common-crypto-fallback.js
+++ b/lib/common-crypto-fallback.js
@@ -16,10 +16,6 @@ if (window.crypto && window.crypto.getRandomValues) {
     window.crypto.getRandomValues(buf);
   };
 } else {
-  console.warn(
-    'Web Crypto API is not supported in your browser!',
-    'Using Math.random() instead.'
-  );
   crypto.randomFillSync = buf => {
     for (let i = 0; i < buf.length; i++) {
       buf[i] = Math.floor(0x100 * Math.random());


### PR DESCRIPTION
Currently JSTP prints a warning about using Math.random() to browser
console unless the browser supports Web Crypto API.  However, the
purpose of this warning isn't clear since it is not actionable and
provides zero value for end users.  Although an extra warning message
that users won't probably see anyway isn't a big issue, it becomes
unnecessary noisy in fake browser environment used for tests (in
particular, I get two warnings for each Jest test case, i.e., about two
thirds of all output).