### PR TITLE
lib: fix invalid args handling in reconnectFn()

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -98,6 +98,8 @@ class Connection extends EventEmitter {
       let transport = options[0];
       if (typeof transport !== 'string' || !transports[transport]) {
         transport = this.client._connectionTransport;
+      } else {
+        options = options.slice(1);
       }
       const callback = common.extractCallback(options) || (() => {});
       if (options.length === 0) {

--- a/test/node/regress-gh-411.js
+++ b/test/node/regress-gh-411.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const test = require('tap');
+
+const jstp = require('../..');
+
+const APP_NAME = 'APP_NAME';
+
+const reconnector = (connection, reconnectFn) => {
+  if (!connection.closedIntentionally) {
+    // Explicit transport passing is the main purpose of this test
+    reconnectFn('net');
+  }
+};
+
+const application = new jstp.Application(APP_NAME, {});
+const serverConfig = { applications: [application] };
+const server = jstp.net.createServer(serverConfig);
+
+server.listen(0, () => {
+  const port = server.address().port;
+  jstp.net.connect(
+    APP_NAME,
+    { reconnector },
+    port,
+    'localhost',
+    (error, connection) => {
+      test.error(error, 'must connect to server and perform handshake');
+
+      connection.getTransport().destroy();
+      connection.on('error', () => {
+        // dismiss
+      });
+
+      connection.on('reconnect', () => {
+        test.pass('must successfully reconnect using specified transport');
+        server.close();
+        connection.close();
+        test.end();
+      });
+    }
+  );
+});


### PR DESCRIPTION
Before, when the transport was passed to the `reconnectFn()`, it was
then not removed from the argument list before passing it on to the
`transport.reconnect()` method.

Co-authored-by: Dmytro Nechai <nechaido@gmail.com>