### PR TITLE
lib: fix ExpiringMap internal storage growing

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -128,6 +128,7 @@ class ExpiringMap extends Map {
     this._deletionTimes.forEach((delTime, key) => {
       if (purgeTime - delTime > this._interval) {
         super.delete(key);
+        this._deletionTimes.delete(key);
       }
     });
   }


### PR DESCRIPTION
Internal storage of ExpiringMap used to store key deletion times was not
cleared after deleting corresponding keys, leading to its indefinite
growth.

Fixes: https://github.com/metarhia/jstp/issues/413