### PR TITLE
cli: improve args serialization

### DIFF
--- a/lib/cli/command-processor.js
+++ b/lib/cli/command-processor.js
@@ -2,8 +2,6 @@
 
 const EventEmitter = require('events').EventEmitter;
 
-const mdsf = require('mdsf');
-
 const jstp = require('../..');
 const utils = require('./utils');
 
@@ -173,9 +171,8 @@ module.exports = class CommandProcessor extends EventEmitter {
         connection.on('event', (interfaceName, eventName, args) => {
           this.cli.log(
             `Received remote event '${eventName}'` +
-              ` in interface '${interfaceName}':\n${mdsf.stringify(
+              ` in interface '${interfaceName}': ${utils.serializeArgs(
                 args,
-                null,
                 this.cli.indent
               )}`
           );

--- a/lib/cli/line-processor.js
+++ b/lib/cli/line-processor.js
@@ -42,12 +42,10 @@ module.exports = class LineProcessor {
         }
         const iface = args[0];
         const method = args[1];
-        const res = mdsf.stringify(
+        const msg = `Method ${iface}.${method} returned: ${utils.serializeArgs(
           result,
-          null,
           this.commandProcessor.cli.indent
-        );
-        const msg = `Method ${iface}.${method} returned:\n${res}`;
+        )}`;
         callback(null, msg);
       }
     );

--- a/lib/cli/utils.js
+++ b/lib/cli/utils.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const mdsf = require('mdsf');
+
 const utils = {};
 module.exports = utils;
 
@@ -92,4 +94,12 @@ utils.iterativeCompletion = (inputs, depth, completer) => {
     if (completer.help) help = completer.help();
   }
   return [completions, help];
+};
+
+utils.serializeArgs = (args, indent) => {
+  if (args.length === 0) return '<empty>';
+  if (typeof indent === 'string' || Number.isInteger(indent)) {
+    return '\n' + args.map(v => mdsf.stringify(v, null, indent)).join(',\n');
+  }
+  return '\n' + mdsf.stringify(args, null, indent).slice(1, -1);
 };


### PR DESCRIPTION
Drop the brackets around the callback/event arguments and output
`'<empty>'` when there are no arguments.