### PR TITLE
Drop support for Node.js versions older than 8.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,6 +3,8 @@ image: Visual Studio 2015
 environment:
   matrix:
     - nodejs_version: 8
+    - nodejs_version: 10
+    - nodejs_version: 12
 
 platform:
   - x86

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,6 @@ image: Visual Studio 2015
 
 environment:
   matrix:
-    - nodejs_version: 6
     - nodejs_version: 8
 
 platform:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,6 @@ environment:
   matrix:
     - nodejs_version: 8
     - nodejs_version: 10
-    - nodejs_version: 12
 
 platform:
   - x86

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - 6
   - 8
   - 10
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - 8
   - 10
+  - 12
 
 os:
   - linux

--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -98,7 +98,7 @@ function outputResults(benchTimeHR) {
 
   const sum = results.reduce(
     (previous, current) =>
-      previous + Math.pow(current[1], 2) + Math.pow(current[0] - mean, 2),
+      previous + current[1] ** 2 + (current[0] - mean) ** 2,
     0
   );
   const stdev = Math.sqrt(sum / workersAmount);

--- a/benchmark/statistics.js
+++ b/benchmark/statistics.js
@@ -15,7 +15,7 @@ const stdev = (sample, meanValue) => {
   if (len === 0 || len === 1) return 0;
   let sum = 0;
   for (let i = 0; i < len; i++) {
-    sum += Math.pow(sample[i] - meanValue, 2);
+    sum += (sample[i] - meanValue) ** 2;
   }
   const variance = sum / len;
   return Math.sqrt(variance);
@@ -43,8 +43,8 @@ const combineStdev = (samples, mean, count) => {
   for (let i = 0; i < samples.length; i++) {
     const sample = samples[i];
     sum +=
-      sample.count * Math.pow(sample.stdev, 2) +
-      sample.count * Math.pow(sample.mean - mean, 2);
+      sample.count * sample.stdev ** 2 +
+      sample.count * (sample.mean - mean) ** 2;
   }
   return Math.sqrt(sum / count);
 };

--- a/lib/session.js
+++ b/lib/session.js
@@ -37,7 +37,7 @@ class Session extends Map {
   // for Session objects when exporting the Session objects.
   //
   toString() {
-    const copy = Object.assign({}, this);
+    const copy = { ...this };
     copy.storage = Array.from(this);
     function replacer(key, value) {
       switch (key) {

--- a/lib/ws-internal.js
+++ b/lib/ws-internal.js
@@ -85,12 +85,13 @@ const allowAllOriginCheckStrategy = function(/* origin */) {
 };
 
 const initServer = function(options, httpServer) {
-  options = Object.assign({}, options, {
+  options = {
+    ...options,
     httpServer,
     autoAcceptConnections: false,
     maxReceivedFrameSize: constants.MAX_MESSAGE_SIZE,
     maxReceivedMessageSize: constants.MAX_MESSAGE_SIZE,
-  });
+  };
 
   httpServer.isOriginAllowed =
     options.originCheckStrategy || allowAllOriginCheckStrategy;

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "prepublish": "npm run -s build-browser"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "readmeFilename": "README.md"
 }

--- a/test/node/application-async-methods.js
+++ b/test/node/application-async-methods.js
@@ -6,17 +6,10 @@ const jstp = require('../..');
 
 const app = require('../fixtures/application');
 
-const makeFakeAsyncFn = fn => {
-  fn[Symbol.toStringTag] = 'AsyncFunction';
-  return fn;
-};
-
 const application = new jstp.Application(app.name, {
   someInterface: {
-    getSessionId: makeFakeAsyncFn(connection =>
-      Promise.resolve(connection.session.id)
-    ),
-    sum: makeFakeAsyncFn((connection, a, b) => Promise.resolve(a + b)),
+    getSessionId: async connection => connection.session.id,
+    sum: async (connection, a, b) => a + b,
   },
 });
 const server = jstp.net.createServer([application]);

--- a/tools/prepare-release.js
+++ b/tools/prepare-release.js
@@ -137,12 +137,10 @@ function getSemverTag(repo, id) {
 }
 
 function httpsGetJson(options) {
-  options = Object.assign(
-    {
-      headers: { 'User-Agent': 'metarhia-jstp-release-tool' },
-    },
-    options
-  );
+  options = {
+    headers: { 'User-Agent': 'metarhia-jstp-release-tool' },
+    ...options,
+  };
   if (token) {
     options.headers['Authorization'] = `token ${token}`;
   }


### PR DESCRIPTION
Also, add Node.js 12 to the Travis CI configuration, update test for `async` application methods, and apply some syntactic sugar that was unavailable before.